### PR TITLE
Make manual connection lifecycle accessible and manageable

### DIFF
--- a/core/android/src/main/kotlin/com/reown/android/internal/common/connection/ManualConnectionLifecycle.kt
+++ b/core/android/src/main/kotlin/com/reown/android/internal/common/connection/ManualConnectionLifecycle.kt
@@ -7,23 +7,26 @@ import com.tinder.scarlet.lifecycle.LifecycleRegistry
 import com.reown.foundation.network.ConnectionLifecycle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
-internal class ManualConnectionLifecycle(
+class ManualConnectionLifecycle(
     private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(),
 ) : Lifecycle by lifecycleRegistry, ConnectionLifecycle {
+
+    private val _onResume = MutableStateFlow<Boolean?>(null)
+    override val onResume: StateFlow<Boolean?> = _onResume.asStateFlow()
+
     fun connect() {
         lifecycleRegistry.onNext(Lifecycle.State.Started)
+        _onResume.value = true
     }
 
     fun disconnect() {
         lifecycleRegistry.onNext(Lifecycle.State.Stopped.WithReason())
+        _onResume.value = false
     }
-
-    override val onResume: StateFlow<Boolean?>
-        get() = MutableStateFlow(null)
-
     override fun reconnect() {
-        lifecycleRegistry.onNext(Lifecycle.State.Stopped.WithReason())
-        lifecycleRegistry.onNext(Lifecycle.State.Started)
+        disconnect()
+        connect()
     }
 }


### PR DESCRIPTION
Since `ManualConnectionLifecycle` is internal and onResume does not change anything, this makes it unusable.

Usage after changes:
```
        CoreClient.initialize(
            ...
            connectionType = ConnectionType.MANUAL,
            ...
        )
```
```
        val manualWalletConnection: ManualConnectionLifecycle by lazy {
            wcKoinApp.koin.get(named(AndroidCommonDITags.MANUAL_CONNECTION_LIFECYCLE))
        }
        
        manualWalletConnection.connect()
        manualWalletConnection.disconnect()
```