### PR TITLE
fix: prevent NoSuchElementException in session chain selection

### DIFF
--- a/product/appkit/src/main/kotlin/com/reown/appkit/domain/delegate/AppKitDelegate.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/domain/delegate/AppKitDelegate.kt
@@ -39,12 +39,16 @@ internal object AppKitDelegate : AppKit.ModalDelegate {
     }
 
     override fun onSessionApproved(approvedSession: Modal.Model.ApprovedSession) {
-        scope.launch {
-            val chain = AppKit.chains.getSelectedChain(AppKit.selectedChain?.id)
+    scope.launch {
+        val chain = AppKit.chains.getSelectedChain(AppKit.selectedChain?.id)
+        if (chain != null) {
             saveSessionUseCase(approvedSession.toSession(chain))
             _wcEventModels.emit(approvedSession)
+        } else {
+            Log.e("AppKitDelegate", "Cannot process session - no chain available")
         }
     }
+}
 
     override fun onSessionAuthenticateResponse(sessionAuthenticateResponse: Modal.Model.SessionAuthenticateResponse) {
         scope.launch {


### PR DESCRIPTION
close #211

- Replace first() with firstOrNull() in getSelectedChain extension function
- Add null safety check in onSessionApproved to handle empty chains case
- This resolves crash when AppKit.chains list is empty during session approval
