### PR TITLE
fix(pos): add clock skew buffer to date range end times

### DIFF
--- a/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
@@ -156,13 +156,19 @@ object Pos {
      *
      * All date boundaries are calculated in the device's local timezone.
      * This means "today" refers to the current local calendar day as perceived by the merchant.
+     *
+     * Note: End times include a 2-minute buffer to account for potential clock skew
+     * between the device and server, ensuring recently completed transactions are included.
      */
     object DateRanges {
+        // Buffer to account for clock skew between device and server
+        private const val CLOCK_SKEW_BUFFER_SECONDS = 120L
+
         /**
-         * Returns a DateRange for today (from local midnight to now).
+         * Returns a DateRange for today (from local midnight to now + buffer).
          */
         fun today(): DateRange {
-            val now = Instant.now()
+            val now = Instant.now().plusSeconds(CLOCK_SKEW_BUFFER_SECONDS)
             val zone = ZoneId.systemDefault()
             val startOfDay = LocalDate.now(zone)
                 .atStartOfDay(zone)
@@ -177,7 +183,7 @@ object Pos {
          */
         fun lastDays(days: Int): DateRange {
             require(days > 0) { "days must be positive" }
-            val now = Instant.now()
+            val now = Instant.now().plusSeconds(CLOCK_SKEW_BUFFER_SECONDS)
             val zone = ZoneId.systemDefault()
             val startOfPeriod = LocalDate.now(zone)
                 .minusDays((days - 1).toLong())
@@ -187,13 +193,13 @@ object Pos {
         }
 
         /**
-         * Returns a DateRange for this week (Monday 00:00 local time to now).
+         * Returns a DateRange for this week (Monday 00:00 local time to now + buffer).
          *
          * Week starts on Monday per ISO-8601. Uses the most recent Monday,
          * which is the same day if today is Monday.
          */
         fun thisWeek(): DateRange {
-            val now = Instant.now()
+            val now = Instant.now().plusSeconds(CLOCK_SKEW_BUFFER_SECONDS)
             val zone = ZoneId.systemDefault()
             val today = LocalDate.now(zone)
             // Calculate days since Monday (Monday=1, Sunday=7) to get previous/same Monday
@@ -204,10 +210,10 @@ object Pos {
         }
 
         /**
-         * Returns a DateRange for this month (1st of month 00:00 local time to now).
+         * Returns a DateRange for this month (1st of month 00:00 local time to now + buffer).
          */
         fun thisMonth(): DateRange {
-            val now = Instant.now()
+            val now = Instant.now().plusSeconds(CLOCK_SKEW_BUFFER_SECONDS)
             val zone = ZoneId.systemDefault()
             val firstOfMonth = LocalDate.now(zone)
                 .withDayOfMonth(1)

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/DateRangesTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/DateRangesTest.kt
@@ -25,14 +25,19 @@ class DateRangesTest {
     }
 
     @Test
-    fun `today - endTime should be close to now`() {
+    fun `today - endTime should include clock skew buffer`() {
         val beforeCall = Instant.now()
         val range = Pos.DateRanges.today()
         val afterCall = Instant.now()
 
+        // endTime should be approximately 2 minutes (120 seconds) after now
+        val bufferSeconds = 120L
+        val expectedMin = beforeCall.plusSeconds(bufferSeconds)
+        val expectedMax = afterCall.plusSeconds(bufferSeconds)
+
         assertTrue(
-            "endTime should be between beforeCall and afterCall",
-            !range.endTime.isBefore(beforeCall) && !range.endTime.isAfter(afterCall)
+            "endTime should be ~2 minutes after now (between $expectedMin and $expectedMax, got ${range.endTime})",
+            !range.endTime.isBefore(expectedMin) && !range.endTime.isAfter(expectedMax)
         )
     }
 


### PR DESCRIPTION
## Summary
- Add 2-minute buffer to `endTime` in all DateRanges functions
- Accounts for clock skew between device and server
- Ensures recently completed transactions appear immediately in filtered views (Today, 7 Days, etc.)

## Problem
After completing a transaction, it wouldn't appear in the "Today" filter until ~1 minute later. This was caused by clock skew between the device and server - the server records timestamps slightly "in the future" from the device's perspective.

## Solution
Add a 120-second buffer to the `endTime` in all DateRanges functions:

```kotlin
private const val CLOCK_SKEW_BUFFER_SECONDS = 120L

fun today(): DateRange {
    val now = Instant.now().plusSeconds(CLOCK_SKEW_BUFFER_SECONDS)
    // ...
}
```

## Test plan
- [ ] Complete a transaction in the POS app
- [ ] Navigate to Transaction History with "Today" filter
- [ ] Verify the transaction appears immediately (no delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)