### PR TITLE
fix: display correct currency symbol in payment UI

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -979,7 +979,7 @@ private fun formatAmount(value: String, decimals: Int, symbol: String): String {
 }
 
 /**
- * Format display amount with $ prefix (for USD amounts).
+ * Format display amount with the appropriate currency symbol.
  */
 private fun formatDisplayAmount(value: String, decimals: Int, symbol: String): String {
     return try {
@@ -992,9 +992,32 @@ private fun formatDisplayAmount(value: String, decimals: Int, symbol: String): S
             maximumFractionDigits = 2
         }
         val formatted = numberFormat.format(formattedValue)
-        "$$formatted"
+        val currencySymbol = getCurrencySymbol(symbol)
+        "$currencySymbol$formatted"
     } catch (e: Exception) {
-        "$$value"
+        val currencySymbol = getCurrencySymbol(symbol)
+        "$currencySymbol$value"
+    }
+}
+
+/**
+ * Get currency symbol for a given currency code.
+ */
+private fun getCurrencySymbol(currencyCode: String): String {
+    return when (currencyCode.uppercase()) {
+        "USD" -> "$"
+        "EUR" -> "\u20AC"
+        "GBP" -> "\u00A3"
+        "JPY" -> "\u00A5"
+        "CNY" -> "\u00A5"
+        "KRW" -> "\u20A9"
+        "INR" -> "\u20B9"
+        "RUB" -> "\u20BD"
+        "BRL" -> "R$"
+        "CHF" -> "CHF "
+        "CAD" -> "CA$"
+        "AUD" -> "A$"
+        else -> "$currencyCode "
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixed incorrect currency symbol display in the sample wallet payment UI
- The `formatDisplayAmount` function was hardcoding `$` for all currencies regardless of the actual currency returned by the API
- Added `getCurrencySymbol` helper function that maps currency codes to their proper symbols

## Problem
When `getPaymentOptions` returned `AmountDisplay(assetSymbol=EUR, ...)`, the UI was incorrectly showing USD (`$`) instead of EUR (`€`).

## Solution
```kotlin
private fun getCurrencySymbol(currencyCode: String): String {
    return when (currencyCode.uppercase()) {
        "USD" -> "$"
        "EUR" -> "€"
        "GBP" -> "£"
        // ... other currencies
        else -> "$currencyCode "
    }
}
```

## Supported Currencies
| Code | Symbol |
|------|--------|
| USD | $ |
| EUR | € |
| GBP | £ |
| JPY | ¥ |
| CNY | ¥ |
| KRW | ₩ |
| INR | ₹ |
| RUB | ₽ |
| BRL | R$ |
| CHF | CHF |
| CAD | CA$ |
| AUD | A$ |

Other currency codes fall back to displaying the code itself (e.g., "SEK 100").

## Test plan
- [ ] Test payment flow with EUR currency
- [ ] Test payment flow with USD currency
- [ ] Verify other supported currencies display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)