### PR TITLE
fix: remove global ProGuard options from consumer rules

### DIFF
--- a/gradle/consumer-rules/walletconnect-rules.pro
+++ b/gradle/consumer-rules/walletconnect-rules.pro
@@ -9,7 +9,4 @@
 -dontwarn org.openjsse.**
 -dontwarn okhttp3.internal.platform.**
 
--allowaccessmodification
--keeppackagenames doNotKeepAThing
-
 -dontwarn groovy.lang.GroovyShell


### PR DESCRIPTION
## Summary
- Removes `-allowaccessmodification` and `-keeppackagenames doNotKeepAThing` from `gradle/consumer-rules/walletconnect-rules.pro`
- These global ProGuard options were being shipped inside the AAR and forced onto consuming apps, causing the Android Studio warning: *"The consumer keep rules contains a global option which should not be specified in library consumer rules"*
- Both options remain in `gradle/proguard-rules/sdk-rules.pro` (build-time rules), so SDK builds are unaffected

Closes #284

## Test plan
- [x] `./gradlew :core:android:assembleRelease` builds successfully
- [x] Inspected `proguard.txt` in output AAR — no global options present
- [ ] Integrate AAR in a consuming app and verify the warning no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)