### PR TITLE
fix: payment success modal stuck after back/forth navigation

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/WalletKitActivity.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/WalletKitActivity.kt
@@ -187,7 +187,9 @@ class WalletKitActivity : AppCompatActivity() {
             .onEach { paymentLink ->
                 navigateWhenReady {
                     val encodedLink = URLEncoder.encode(paymentLink, "UTF-8")
-                    navController.navigate("${Route.Payment.path}/$encodedLink")
+                    navController.navigate("${Route.Payment.path}/$encodedLink") {
+                        launchSingleTop = true
+                    }
                 }
             }
             .launchIn(lifecycleScope)
@@ -209,7 +211,9 @@ class WalletKitActivity : AppCompatActivity() {
             lifecycleScope.launch {
                 navigateWhenReady {
                     val encodedLink = URLEncoder.encode(dataString, "UTF-8")
-                    navController.navigate("${Route.Payment.path}/$encodedLink")
+                    navController.navigate("${Route.Payment.path}/$encodedLink") {
+                        launchSingleTop = true
+                    }
                 }
             }
             return

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -133,7 +133,7 @@ fun PaymentRoute(
                             onWhyInfoRequired = { viewModel.showWhyInfoRequired() },
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -148,7 +148,7 @@ fun PaymentRoute(
                             },
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -159,7 +159,7 @@ fun PaymentRoute(
                             onConfirm = { viewModel.confirmFromSummary() },
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -168,7 +168,7 @@ fun PaymentRoute(
                             onBack = { viewModel.dismissWhyInfoRequired() },
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -177,7 +177,7 @@ fun PaymentRoute(
                             message = state.message,
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -187,13 +187,13 @@ fun PaymentRoute(
                             onDone = {
                                 viewModel.cancel()
                                 onPaymentSuccess()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                                 Toast.makeText(context, "Payment successful!", Toast.LENGTH_SHORT).show()
                             },
                             onClose = {
                                 viewModel.cancel()
                                 onPaymentSuccess()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -202,11 +202,11 @@ fun PaymentRoute(
                             message = state.message,
                             onRetry = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             },
                             onClose = {
                                 viewModel.cancel()
-                                navController.popBackStack(Route.Connections.path, inclusive = false)
+                                dismissPaymentDialog(navController)
                             }
                         )
                     }
@@ -215,6 +215,12 @@ fun PaymentRoute(
                 }
             }
         }
+    }
+}
+
+private fun dismissPaymentDialog(navController: NavHostController) {
+    if (!navController.popBackStack(Route.Connections.path, inclusive = false)) {
+        navController.popBackStack()
     }
 }
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -61,6 +61,8 @@ class PaymentViewModel : ViewModel() {
      * Always goes directly to Options state (no Intro screen).
      */
     private fun processPaymentOptionsResponse(response: Wallet.Model.PaymentOptionsResponse) {
+        // Clear replay cache immediately after consuming to prevent stale data leaking to other ViewModel instances
+        WalletKitDelegate.clearPaymentOptions()
         currentPaymentId = response.paymentId
         collectedValues.clear()
         currentFieldIndex = 0


### PR DESCRIPTION
## Summary
- Prevent payment dialog entries from stacking on the navigation backstack by adding `launchSingleTop = true` to both payment navigation calls in `WalletKitActivity`
- Add fallback `popBackStack()` in `PaymentRoute` so the dialog always dismisses, even if the targeted pop to `Route.Connections` fails
- Clear the `paymentOptionsEvent` replay cache eagerly in `PaymentViewModel` after consuming the event, preventing stale data from leaking to duplicate ViewModel instances

## Test plan
- [ ] Initiate a payment, go back, initiate again, go back and forth several times, then complete the payment
- [ ] Verify the success modal dismisses when clicking "Got it" or X
- [ ] Verify only one toast message appears
- [ ] Verify navigation returns to the Connections screen
- [ ] Verify deep link payment flow still works correctly
- [ ] Verify QR code payment flow still works correctly

Fixes WCP4-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)