### PR TITLE
fix: remove broken close staging step from release pipeline

### DIFF
--- a/.github/workflows/ci_release_artifacts.yml
+++ b/.github/workflows/ci_release_artifacts.yml
@@ -80,15 +80,6 @@ jobs:
         run: |
           ./gradlew releaseAllSDKs -Ptype=sonatype
 
-      - name: Close staging repositories
-        env:
-          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
-          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
-          REOWN_SONATYPE_STAGING_PROFILE_ID: ${{ secrets.REOWN_SONATYPE_STAGING_PROFILE_ID }}
-          WC_SONATYPE_STAGING_PROFILE_ID: ${{ secrets.WC_SONATYPE_STAGING_PROFILE_ID }}
-        run: |
-          ./gradlew closeReownStagingRepository closeWalletconnectStagingRepository
-
       - name: Upload staging repositories to Central Portal and release
         env:
           CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,17 +132,19 @@ tasks.register("closeAndReleaseMultipleRepositories") {
         println("Processing ${openRepos.size} open repositories and ${closedRepos.size} closed repositories")
 
         if (openRepos.isNotEmpty()) {
-            println("WARNING: Found ${openRepos.size} open repositories. These must be closed before upload.")
-            println("Open repos will be skipped. Run closeReownStagingRepository/closeWalletconnectStagingRepository first.")
+            println("Uploading ${openRepos.size} open repositories to Central Portal")
+            uploadRepositoriesToPortal(openRepos)
         }
 
-        if (closedRepos.isEmpty()) {
-            throw RuntimeException("No closed staging repositories found. Ensure repos are closed before uploading. " +
-                "Run closeReownStagingRepository and closeWalletconnectStagingRepository first.")
+        if (closedRepos.isNotEmpty()) {
+            println("Uploading ${closedRepos.size} closed repositories to Central Portal")
+            uploadRepositoriesToPortal(closedRepos)
         }
 
-        println("Uploading ${closedRepos.size} closed repositories to Central Portal")
-        uploadRepositoriesToPortal(closedRepos)
+        if (openRepos.isEmpty() && closedRepos.isEmpty()) {
+            println("No repositories to upload to Portal")
+            return@doLast
+        }
 
         println("Starting to wait for artifacts to be available on Maven Central...")
         // Wait for artifacts to be available on Maven Central since we're using automatic publishing


### PR DESCRIPTION
## Summary
- Removed the "Close staging repositories" workflow step that used `closeReownStagingRepository`/`closeWalletconnectStagingRepository` tasks from the `nexus-publish` plugin — these tasks track staging repo IDs in-memory and fail when run in a separate Gradle invocation from the publish step
- Restored `closeAndReleaseMultipleRepositories` to upload both open and closed staging repos to Central Portal (the `automatic` publishing type handles validation and release regardless of repo state)

Fixes the CI failure: https://github.com/reown-com/reown-kotlin/actions/runs/22132450445/job/63975661532

## Test plan
- [ ] Merge to `develop`, then to `master` to trigger the release workflow
- [ ] Verify the "Upload staging repositories to Central Portal and release" step succeeds
- [ ] Verify artifacts appear on Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)