### PR TITLE
fix: use gh API for tag creation and switch to USER_MANAGED publishing

### DIFF
--- a/.github/workflows/ci_release_artifacts.yml
+++ b/.github/workflows/ci_release_artifacts.yml
@@ -96,23 +96,19 @@ jobs:
           echo "bom_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted BOM version: $VERSION"
 
-      - name: Create git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          TAG="BOM_${{ steps.version.outputs.bom_version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping tag creation"
-          else
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
-      - name: Create GitHub Release
+      - name: Create git tag and GitHub Release
         env:
           GH_TOKEN: ${{ secrets.PUSH_GITHUB_TOKEN }}
         run: |
-          gh release create "BOM_${{ steps.version.outputs.bom_version }}" \
+          TAG="BOM_${{ steps.version.outputs.bom_version }}"
+          if gh api repos/${{ github.repository }}/git/refs/tags/$TAG >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping tag creation"
+          else
+            gh api repos/${{ github.repository }}/git/refs \
+              -f ref="refs/tags/$TAG" \
+              -f sha="${{ github.sha }}"
+          fi
+          gh release create "$TAG" \
             --target master \
-            --title "BOM_${{ steps.version.outputs.bom_version }}" \
+            --title "$TAG" \
             --generate-notes


### PR DESCRIPTION
## Summary
- **Fix tag push 403 error**: Create git tags via `gh api` with `PUSH_GITHUB_TOKEN` instead of `git push` which fails because the default `GITHUB_TOKEN` has read-only `Contents` permission
- **Merge tag + release steps** into one since they share the same `GH_TOKEN`
- **Switch `publishing_type` from `automatic` to `USER_MANAGED`** so artifacts can be reviewed and published manually from the Central Portal dashboard (automatic wasn't reliably publishing)
- **Remove `waitForArtifactsToBeAvailable`** polling loop since it's not needed with user-managed publishing

Fixes: https://github.com/reown-com/reown-kotlin/actions/runs/22137041542/job/63991318247

## Test plan
- [ ] Merge to `develop`, then to `master` to trigger the release workflow
- [ ] Verify git tag is created successfully via gh API
- [ ] Verify GitHub Release is created
- [ ] Verify artifacts appear in Central Portal dashboard for manual publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)