### PR TITLE
fix: use gh API for tag creation and fix automatic publishing

### DIFF
--- a/.github/workflows/ci_release_artifacts.yml
+++ b/.github/workflows/ci_release_artifacts.yml
@@ -96,23 +96,19 @@ jobs:
           echo "bom_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted BOM version: $VERSION"
 
-      - name: Create git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          TAG="BOM_${{ steps.version.outputs.bom_version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping tag creation"
-          else
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
-      - name: Create GitHub Release
+      - name: Create git tag and GitHub Release
         env:
           GH_TOKEN: ${{ secrets.PUSH_GITHUB_TOKEN }}
         run: |
-          gh release create "BOM_${{ steps.version.outputs.bom_version }}" \
+          TAG="BOM_${{ steps.version.outputs.bom_version }}"
+          if gh api repos/${{ github.repository }}/git/refs/tags/$TAG >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping tag creation"
+          else
+            gh api repos/${{ github.repository }}/git/refs \
+              -f ref="refs/tags/$TAG" \
+              -f sha="${{ github.sha }}"
+          fi
+          gh release create "$TAG" \
             --target master \
-            --title "BOM_${{ steps.version.outputs.bom_version }}" \
+            --title "$TAG" \
             --generate-notes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,7 +147,6 @@ tasks.register("closeAndReleaseMultipleRepositories") {
         }
 
         println("Starting to wait for artifacts to be available on Maven Central...")
-        // Wait for artifacts to be available on Maven Central since we're using automatic publishing
         waitForArtifactsToBeAvailable()
         println("closeAndReleaseMultipleRepositories task completed successfully!")
     }
@@ -249,7 +248,7 @@ fun uploadRepositoriesToPortal(repositories: List<StagingRepository>) {
 }
 
 fun uploadRepositoryToPortal(repositoryKey: String, maxRetries: Int = 3) {
-    val uploadUrl = "$manualApiUrl/upload/repository/$repositoryKey"
+    val uploadUrl = "$manualApiUrl/upload/repository/$repositoryKey?publishing_type=automatic"
     println("Starting upload for repository: $repositoryKey")
     println("Upload URL: $uploadUrl")
 
@@ -260,8 +259,6 @@ fun uploadRepositoryToPortal(repositoryKey: String, maxRetries: Int = 3) {
             try {
                 val httpPost = HttpPost(uploadUrl).apply {
                     setHeader("Authorization", authHeader())
-                    setHeader("Content-Type", "application/json")
-                    entity = StringEntity("""{"publishing_type": "automatic"}""")
                 }
 
                 println("Executing HTTP POST request (attempt ${attempt + 1}/$maxRetries)...")


### PR DESCRIPTION
## Summary
- **Fix tag push 403 error**: Create git tags via `gh api` with `PUSH_GITHUB_TOKEN` instead of `git push` which fails because the default `GITHUB_TOKEN` has read-only `Contents` permission
- **Merge tag + release steps** into a single step since they share the same `GH_TOKEN`
- **Fix automatic publishing**: `publishing_type` must be a URL **query parameter**, not a JSON body field. The API was ignoring the JSON body and defaulting to `user_managed`, requiring manual publishing from the dashboard. Fixed to `?publishing_type=automatic` on the URL
- **Re-enable `waitForArtifactsToBeAvailable`** since automatic publishing should now work correctly

Fixes: https://github.com/reown-com/reown-kotlin/actions/runs/22137041542/job/63991318247

## Test plan
- [ ] Merge to `develop`, then to `master` to trigger the release workflow
- [ ] Verify git tag is created successfully via gh API
- [ ] Verify GitHub Release is created
- [ ] Verify artifacts are **automatically** published to Maven Central (no manual dashboard action needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)