### PR TITLE
feat: add Canton blockchain integration to sample wallet

### DIFF
--- a/sample/common/src/main/kotlin/com/reown/sample/common/Chains.kt
+++ b/sample/common/src/main/kotlin/com/reown/sample/common/Chains.kt
@@ -200,5 +200,19 @@ enum class Chains(
             override val defaultEvents: List<String> = listOf()
             override val defaultMethods: List<String> = listOf("solana_signMessage", "solana_signTransaction", "solana_signAndSendTransaction", "solana_signAllTransactions")
         }
+
+        object Canton : Info() {
+            override val chain = "canton"
+            override val defaultEvents: List<String> = listOf("accountsChanged", "statusChanged", "chainChanged")
+            override val defaultMethods: List<String> = listOf(
+                "canton_prepareSignExecute",
+                "canton_listAccounts",
+                "canton_getPrimaryAccount",
+                "canton_getActiveNetwork",
+                "canton_status",
+                "canton_ledgerApi",
+                "canton_signMessage"
+            )
+        }
     }
 }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/account/CantonAccountDelegate.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/account/CantonAccountDelegate.kt
@@ -1,0 +1,16 @@
+@file:JvmSynthetic
+
+package com.reown.sample.wallet.domain.account
+
+object CantonAccountDelegate {
+    const val PARTY_ID = "operator::1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+    const val PARTY_ID_URL_ENCODED = "operator%3A%3A1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+    const val PUBLIC_KEY_BASE64 = "q83vEjRWeJCrze8SNFZbkKvN7xI0VluQq83vEjRWeJg="
+    const val NAMESPACE = "1220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678"
+
+    const val mainnet = "canton:mainnet"
+    const val devnet = "canton:devnet"
+
+    val caip10MainnetAddress: String = "$mainnet:$PARTY_ID_URL_ENCODED"
+    val caip10DevnetAddress: String = "$devnet:$PARTY_ID_URL_ENCODED"
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/signer/Signer.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/signer/Signer.kt
@@ -3,6 +3,7 @@ package com.reown.sample.wallet.domain.signer
 import com.reown.sample.common.Chains
 import com.reown.sample.wallet.domain.StacksAccountDelegate
 import com.reown.sample.wallet.domain.WalletKitDelegate
+import com.reown.sample.wallet.domain.account.CantonAccountDelegate
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
 import com.reown.sample.wallet.domain.account.SuiAccountDelegate
 import com.reown.sample.wallet.domain.account.TONAccountDelegate
@@ -218,6 +219,47 @@ object Signer {
                 val rawDataHex = transaction.getString("raw_data_hex")
                 val signedTx = tronSignTransaction(rawDataHex, TronAccountDelegate.keypair)
                 """{"signature":["${signedTx.signature}"],"txID":"${signedTx.txId}","raw_data_hex":"$rawDataHex"}"""
+            }
+
+            // Canton methods
+            sessionRequest.method == "canton_listAccounts" -> {
+                val networkId = sessionRequest.chain ?: "canton:devnet"
+                """[{"primary":true,"partyId":"${CantonAccountDelegate.PARTY_ID}","status":"allocated","hint":"operator","publicKey":"${CantonAccountDelegate.PUBLIC_KEY_BASE64}","namespace":"${CantonAccountDelegate.NAMESPACE}","networkId":"$networkId","signingProviderId":"participant","disabled":false}]"""
+            }
+
+            sessionRequest.method == "canton_getPrimaryAccount" -> {
+                val networkId = sessionRequest.chain ?: "canton:devnet"
+                """{"primary":true,"partyId":"${CantonAccountDelegate.PARTY_ID}","status":"allocated","hint":"operator","publicKey":"${CantonAccountDelegate.PUBLIC_KEY_BASE64}","namespace":"${CantonAccountDelegate.NAMESPACE}","networkId":"$networkId","signingProviderId":"participant"}"""
+            }
+
+            sessionRequest.method == "canton_getActiveNetwork" -> {
+                val networkId = sessionRequest.chain ?: "canton:devnet"
+                """{"networkId":"$networkId","ledgerApi":"http://127.0.0.1:5003"}"""
+            }
+
+            sessionRequest.method == "canton_status" -> {
+                val networkId = sessionRequest.chain ?: "canton:devnet"
+                """{"provider":{"id":"remote-da","version":"3.4.0","providerType":"remote"},"connection":{"isConnected":true,"isNetworkConnected":true},"network":{"networkId":"$networkId","ledgerApi":"http://127.0.0.1:5003"}}"""
+            }
+
+            sessionRequest.method == "canton_ledgerApi" -> {
+                val params = try { JSONObject(sessionRequest.param) } catch (_: Exception) { JSONObject() }
+                val resource = try { params.getString("resource") } catch (_: Exception) { "/unknown" }
+                if (resource == "/v2/version") {
+                    """{"response":"{\"version\":\"3.4.0\",\"features\":{}}"}"""
+                } else {
+                    """{"response":"{\"mock\":true,\"resource\":\"$resource\"}"}"""
+                }
+            }
+
+            sessionRequest.method == "canton_signMessage" -> {
+                """{"signature":"${CantonAccountDelegate.PUBLIC_KEY_BASE64}","publicKey":"${CantonAccountDelegate.PUBLIC_KEY_BASE64}"}"""
+            }
+
+            sessionRequest.method == "canton_prepareSignExecute" -> {
+                val params = try { JSONObject(sessionRequest.param) } catch (_: Exception) { JSONObject() }
+                val commandId = try { params.getString("commandId") } catch (_: Exception) { "mock-command-id-${System.currentTimeMillis()}" }
+                """{"status":"executed","commandId":"$commandId","payload":{"updateId":"mock-tx-update-id","completionOffset":42}}"""
             }
 
             //Note: Only for testing purposes - it will always fail on Dapp side

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/ChainUtils.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/ChainUtils.kt
@@ -59,6 +59,9 @@ private val chainRegistry: Map<String, ChainInfo> = mapOf(
     // TRON
     "tron:0x2b6653dc" to ChainInfo("Tron", R.drawable.ic_tron, Color(0xFFFF0013), "Tr"),
     "tron:0xcd8690dc" to ChainInfo("Tron Testnet", R.drawable.ic_tron, Color(0xFFFF0013), "Tr"),
+    // Canton
+    "canton:mainnet" to ChainInfo("Canton Mainnet", null, Color(0xFF4A90D9), "Ca"),
+    "canton:devnet" to ChainInfo("Canton Devnet", null, Color(0xFF4A90D9), "Ca"),
 )
 
 fun chainInfo(chainId: String): Pair<Color, String> {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/session_proposal/SessionProposalUI.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/session_proposal/SessionProposalUI.kt
@@ -4,6 +4,7 @@ import com.reown.sample.wallet.domain.StacksAccountDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
 import com.reown.sample.wallet.domain.account.TONAccountDelegate
+import com.reown.sample.wallet.domain.account.CantonAccountDelegate
 import com.reown.sample.wallet.domain.account.TronAccountDelegate
 import com.reown.sample.wallet.domain.account.SuiAccountDelegate
 import com.reown.sample.wallet.ui.common.peer.PeerContextUI
@@ -151,6 +152,23 @@ fun walletMetaData(): WalletMetaData {
                 methods = listOf("tron_signMessage", "tron_signTransaction"),
                 events = listOf(),
                 accounts = listOf(TronAccountDelegate.caip10MainnetAddress)
+            ),
+            "canton" to Wallet.Model.Namespace.Session(
+                chains = listOf(CantonAccountDelegate.mainnet, CantonAccountDelegate.devnet),
+                methods = listOf(
+                    "canton_prepareSignExecute",
+                    "canton_listAccounts",
+                    "canton_getPrimaryAccount",
+                    "canton_getActiveNetwork",
+                    "canton_status",
+                    "canton_ledgerApi",
+                    "canton_signMessage"
+                ),
+                events = listOf("accountsChanged", "statusChanged", "chainChanged"),
+                accounts = listOf(
+                    CantonAccountDelegate.caip10MainnetAddress,
+                    CantonAccountDelegate.caip10DevnetAddress
+                )
             )
         )
     )

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/session_proposal/SessionProposalViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/session_proposal/SessionProposalViewModel.kt
@@ -10,6 +10,7 @@ import com.reown.sample.wallet.domain.StacksAccountDelegate
 import com.reown.sample.wallet.domain.StacksAccountDelegate.wallet
 import com.reown.android.BuildConfig as AndroidBuildConfig
 import com.reown.sample.wallet.domain.WalletKitDelegate
+import com.reown.sample.wallet.domain.account.CantonAccountDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
 import com.reown.sample.wallet.domain.account.SuiAccountDelegate
@@ -120,6 +121,16 @@ class SessionProposalViewModel : ViewModel() {
                                 )
                             }
 
+                            chainId.contains("canton") -> {
+                                val issuer = "did:pkh:$chainId:${CantonAccountDelegate.PARTY_ID_URL_ENCODED}"
+                                Pair(
+                                    Wallet.Model.Cacao.Signature(
+                                        t = "canton",
+                                        s = CantonAccountDelegate.PUBLIC_KEY_BASE64
+                                    ), issuer
+                                )
+                            }
+
                             else -> Pair(
                                 Wallet.Model.Cacao.Signature(
                                     t = "",
@@ -224,6 +235,7 @@ class SessionProposalViewModel : ViewModel() {
                     chainId.contains("stacks") -> Stacks.getAddress(wallet, Stacks.Version.mainnetP2PKH)
                     chainId.contains("sui") -> SuiAccountDelegate.address
                     chainId.contains("tron") -> TronAccountDelegate.address
+                    chainId.contains("canton") -> CantonAccountDelegate.PARTY_ID_URL_ENCODED
                     else -> EthAccountDelegate.address
                 }
                 val issuer = "did:pkh:$chainId:$address"

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/transaction/TokenAddresses.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/transaction/TokenAddresses.kt
@@ -11,7 +11,9 @@ enum class Chain(val id: String) {
     SUI("sui:mainnet"),
     SUI_TESTNET("sui:testnet"),
     TRON("tron:0x2b6653dc"),
-    CELO("eip155:42220")
+    CELO("eip155:42220"),
+    CANTON_MAINNET("canton:mainnet"),
+    CANTON_DEVNET("canton:devnet"),
 }
 
 interface Token


### PR DESCRIPTION
## Summary
- Add Canton namespace (`canton:mainnet`, `canton:devnet`) to the sample wallet so it can connect to react-dapp via WalletConnect and respond to Canton RPC methods with mocked responses
- All 7 Canton methods return hardcoded mock data: `canton_listAccounts`, `canton_getPrimaryAccount`, `canton_getActiveNetwork`, `canton_status`, `canton_ledgerApi`, `canton_signMessage`, `canton_prepareSignExecute`
- Hardcoded party ID (`operator::1220...`) with URL-encoded CAIP-10 accounts per the Canton spec

```mermaid
flowchart LR
    subgraph react-dapp
        A[Canton RPC request]
    end
    subgraph kotlin-wallet
        B[WalletKitDelegate] --> C[SessionRequestViewModel]
        C --> D[Signer.sign]
        D --> E[Mock Canton responses]
    end
    A -->|WalletConnect| B
    E -->|JSON-RPC result| A
```

### Files changed
| File | Change |
|------|--------|
| `CantonAccountDelegate.kt` | **New** — hardcoded Canton account constants |
| `Chains.kt` | Added `Info.Canton` with methods/events |
| `TokenAddresses.kt` | Added `CANTON_MAINNET`, `CANTON_DEVNET` chain entries |
| `ChainUtils.kt` | Added chain registry entries (blue "Ca" circle) |
| `SessionProposalUI.kt` | Added `"canton"` namespace to `walletMetaData()` |
| `Signer.kt` | Added mock response handlers for all 7 Canton methods |
| `SessionProposalViewModel.kt` | Added Canton auth case for session approval |

### Context
- Canton spec: WalletConnectFoundation/docs#139
- React wallet/dapp reference: reown-com/web-examples#1017

## Test plan
- [ ] Build: `./gradlew :sample:wallet:assembleDebug` passes
- [ ] Connect Kotlin wallet to react-dapp-v2 with Canton chains selected
- [ ] Session proposal shows Canton chains with "Ca" blue circles
- [ ] Approve session — Canton namespace included
- [ ] Send each Canton RPC method from dapp → wallet shows approval dialog → approve → mock response returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)