### PR TITLE
feat(pos): poll until terminal state, add stopPolling API

### DIFF
--- a/product/pos/src/main/kotlin/com/walletconnect/pos/PosClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/PosClient.kt
@@ -191,6 +191,27 @@ object PosClient {
     }
 
     /**
+     * Stops polling for payment status without cancelling the payment.
+     *
+     * Use this to unblock the POS UI while the payment may still complete
+     * on the server. Unlike [pause], the polling state is cleared and
+     * [resume] will have no effect after this call. Unlike [cancelPayment],
+     * no cancel request is sent to the server.
+     *
+     * @return The paymentId of the stopped payment, or null if no payment
+     *         was being polled. Use this with [checkPaymentStatus] later.
+     */
+    fun stopPolling(): String? {
+        synchronized(lock) {
+            val paymentId = apiClient?.activePollingState?.paymentId
+            currentPollingJob?.cancel()
+            currentPollingJob = null
+            apiClient?.clearActivePollingState()
+            return paymentId
+        }
+    }
+
+    /**
      * Fetches transaction history for the merchant.
      *
      * @param limit Number of transactions to fetch per page (default 20, max 200)

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
@@ -57,7 +57,6 @@ internal class ApiClient(
 
     internal data class ActivePollingState(
         val paymentId: String,
-        val expiresAt: Long,
         val context: PaymentContext
     )
 
@@ -99,7 +98,7 @@ internal class ApiClient(
                 onEvent(paymentCreatedEvent)
 
                 if (!data.isFinal) {
-                    startPolling(data.paymentId, data.expiresAt, context, onEvent)
+                    startPolling(data.paymentId, context, onEvent)
                 }
             } else {
                 val error = parseErrorResponse(response)
@@ -136,28 +135,20 @@ internal class ApiClient(
 
     suspend fun resumePolling(onEvent: (Pos.PaymentEvent) -> Unit) {
         val state = activePollingState ?: return
-        startPolling(state.paymentId, state.expiresAt, state.context, onEvent)
+        startPolling(state.paymentId, state.context, onEvent)
     }
 
     private suspend fun startPolling(
         paymentId: String,
-        expiresAt: Long,
         context: PaymentContext,
         onEvent: (Pos.PaymentEvent) -> Unit
     ) {
-        activePollingState = ActivePollingState(paymentId, expiresAt, context)
+        activePollingState = ActivePollingState(paymentId, context)
         var lastEmittedStatus: String? = null
         var consecutiveTransientErrors = 0
 
         try {
             while (true) {
-                if (System.currentTimeMillis() / 1000 >= expiresAt) {
-                    val expiredError = Pos.PaymentEvent.PaymentError.PaymentExpired("Payment has expired")
-                    eventTracker.trackPaymentFailed(paymentId, context, expiredError)
-                    onEvent(expiredError)
-                    break
-                }
-
                 when (val result = getPaymentStatus(paymentId)) {
                     is ApiResult.Success -> {
                         val data = result.data

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -361,6 +361,11 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
         _isLoading.value = false
     }
 
+    fun stopPolling(): String? {
+        _isLoading.value = false
+        return PosClient.stopPolling()
+    }
+
     fun printReceipt() {
         // TODO: Implement receipt printing via POS terminal SDK
     }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentScreen.kt
@@ -94,6 +94,7 @@ fun PaymentScreen(
             val remaining = expiresAt - now
             if (remaining <= 0) {
                 if (uiState is PaymentUiState.WaitingForScan) {
+                    viewModel.stopPolling()
                     navigateToErrorScreen("expired")
                 }
                 break


### PR DESCRIPTION
## Summary

- **Remove client-side `expiresAt` expiry check** from the polling loop in `ApiClient`. The SDK now polls until the server returns a terminal status (`succeeded`, `expired`, `failed`, `cancelled`), eliminating premature expiry caused by device clock skew.
- **Add `PosClient.stopPolling(): String?`** — a new public API that cancels polling without cancelling the payment on the backend. Returns the `paymentId` so merchants can later call `checkPaymentStatus()`. This lets the POS UI unblock (e.g., when stuck in `processing`) without losing the payment.
- **Update sample app** to call `stopPolling()` when the local countdown timer expires, cleanly stopping SDK polling before navigating away.

```mermaid
graph LR
    A[pause] -->|stops polling| B[state preserved]
    B -->|resume| C[polling restarts]
    D[stopPolling] -->|stops polling| E[state cleared]
    E -->|resume| F[no-op]
    G[cancelPayment] -->|stops polling| H[state cleared]
    H -->|sends cancel API| I[payment cancelled]
```

## Test plan

- [x] `./gradlew :product:pos:build` — passes
- [x] `./gradlew :product:pos:testDebugUnitTest` — all tests pass
- [x] `./gradlew :sample:pos:assembleDebug` — compiles
- [ ] Manual: create a payment, verify polling continues past `expiresAt` until server terminal state
- [ ] Manual: call `stopPolling()` during processing, verify POS UI unblocks and payment is NOT cancelled on backend
- [ ] Manual: after `stopPolling()`, verify `resume()` is a no-op


🤖 Generated with [Claude Code](https://claude.com/claude-code)