### PR TITLE
feat: send deviceId in ingest event payload

### DIFF
--- a/product/pos/src/main/kotlin/com/walletconnect/pos/PosClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/PosClient.kt
@@ -74,7 +74,7 @@ object PosClient {
 
             val newScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
             scope = newScope
-            eventTracker = EventTracker(merchantId, newScope, sharedMoshi, baseHttpClient)
+            eventTracker = EventTracker(merchantId, deviceId, newScope, sharedMoshi, baseHttpClient)
             errorTracker = ErrorTracker(newScope, sharedMoshi, baseHttpClient)
             apiClient = ApiClient(apiKey, merchantId, eventTracker!!, errorTracker!!, sharedMoshi, mtlsClient, apiBaseUrl)
         }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
@@ -22,6 +22,7 @@ internal data class IngestEventRequest(
 
 @JsonClass(generateAdapter = true)
 internal data class EventPayload(
+    @param:Json(name = "device_id") val deviceId: String? = null,
     // Payment context fields (for non-error events)
     @param:Json(name = "payment_url") val paymentUrl: String? = null,
     @param:Json(name = "amount") val amount: PaymentAmountPayload? = null,

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventTracker.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventTracker.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 internal class EventTracker(
     private val merchantId: String,
+    private val deviceId: String,
     private val scope: CoroutineScope,
     moshi: Moshi,
     baseHttpClient: OkHttpClient,
@@ -101,7 +102,7 @@ internal class EventTracker(
                 sdkName = "pos-kotlin",
                 sdkVersion = BuildConfig.SDK_VERSION,
                 merchantId = merchantId,
-                payload = payload
+                payload = (payload ?: EventPayload()).copy(deviceId = deviceId)
             )
 
             // Fire-and-forget: launch on IO dispatcher with silent exception handling


### PR DESCRIPTION
## Summary
- Wire the `deviceId` from `PosClient.init()` through `EventTracker` into every `EventPayload` sent to the ingest endpoint
- The `device_id` field is included in the `payload` object of all ingest events

## Test plan
- [x] Existing `PosClientTest` unit tests pass
- [ ] Verify ingest events contain `device_id` in the payload on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)