### PR TITLE
fix(maestro): stabilize wallet sample e2e flows after UI refactor

### DIFF
--- a/.maestro/flows/native/connect_confirm.yaml
+++ b/.maestro/flows/native/connect_confirm.yaml
@@ -6,7 +6,7 @@ name: Kotlin Dapp to Kotlin Wallet Connection Confirmed
     permissions:
       all: allow
 - startRecording: "Native Connection Confirmed"
-# Press NOT NOW in case the Enabling testing features modal appear
+# Press NOT NOW in case the Enabling testing features modal appears
 - runFlow:
     when:
       visible: "NOT NOW"

--- a/.maestro/flows/native/connect_confirm.yaml
+++ b/.maestro/flows/native/connect_confirm.yaml
@@ -6,6 +6,12 @@ name: Kotlin Dapp to Kotlin Wallet Connection Confirmed
     permissions:
       all: allow
 - startRecording: "Native Connection Confirmed"
+# Press NOT NOW in case the Enabling testing features modal appear
+- runFlow:
+    when:
+      visible: "NOT NOW"
+    commands:
+      - tapOn: "NOT NOW"
 - extendedWaitUntil:
     visible:
       text: "Chain selection"
@@ -28,9 +34,10 @@ name: Kotlin Dapp to Kotlin Wallet Connection Confirmed
 - tapOn: "Android Sample Internal"
 - extendedWaitUntil:
     visible:
-      text: "Connect"
+      id: "wallet-request-approve"
     timeout: 30000
-- tapOn: "Connect"
+- tapOn:
+    id: "wallet-request-approve"
 - extendedWaitUntil:
     visible:
       text: "Ethereum_main"

--- a/.maestro/flows/native/connect_reject.yaml
+++ b/.maestro/flows/native/connect_reject.yaml
@@ -9,6 +9,12 @@ name: Kotlin Dapp to Kotlin Wallet Connection Rejected
     appId: "com.reown.sample.dapp.internal"
     permissions:
       all: allow
+# Press NOT NOW in case the Enabling testing features modal appear
+- runFlow:
+    when:
+      visible: "NOT NOW"
+    commands:
+      - tapOn: "NOT NOW"
 - extendedWaitUntil:
     visible:
       text: "Chain selection"
@@ -31,9 +37,10 @@ name: Kotlin Dapp to Kotlin Wallet Connection Rejected
 - tapOn: "Android Sample Internal"
 - extendedWaitUntil:
     visible:
-      text: "Cancel"
+      id: "wallet-request-reject"
     timeout: 30000
-- tapOn: "Cancel"
+- tapOn:
+    id: "wallet-request-reject"
 - extendedWaitUntil:
     visible:
       text: "Connection declined"

--- a/.maestro/flows/native/connect_reject.yaml
+++ b/.maestro/flows/native/connect_reject.yaml
@@ -9,7 +9,7 @@ name: Kotlin Dapp to Kotlin Wallet Connection Rejected
     appId: "com.reown.sample.dapp.internal"
     permissions:
       all: allow
-# Press NOT NOW in case the Enabling testing features modal appear
+# Press NOT NOW in case the Enabling testing features modal appears
 - runFlow:
     when:
       visible: "NOT NOW"

--- a/.maestro/flows/native/personal_sign_confirm.yaml
+++ b/.maestro/flows/native/personal_sign_confirm.yaml
@@ -13,9 +13,10 @@ name: Kotlin Dapp to Kotlin Wallet personal_sign Confirmed
 - tapOn: "personal_sign"
 - extendedWaitUntil:
     visible:
-      text: "Sign"
+      id: "wallet-request-approve"
     timeout: 30000
-- tapOn: "Sign"
+- tapOn:
+    id: "wallet-request-approve"
 - extendedWaitUntil:
     visible:
       text: "result_message"

--- a/.maestro/flows/native/personal_sign_confirm.yaml
+++ b/.maestro/flows/native/personal_sign_confirm.yaml
@@ -5,6 +5,12 @@ name: Kotlin Dapp to Kotlin Wallet personal_sign Confirmed
     permissions:
       all: allow
 - startRecording: "Native personal_sign Confirmed"
+# Press NOT NOW in case the Enabling testing features modal appears
+- runFlow:
+    when:
+      visible: "NOT NOW"
+    commands:
+      - tapOn: "NOT NOW"
 - extendedWaitUntil:
     visible:
       text: "Ethereum_Main"

--- a/.maestro/flows/native/personal_sign_reject.yaml
+++ b/.maestro/flows/native/personal_sign_reject.yaml
@@ -5,6 +5,12 @@ name: Kotlin Dapp to Kotlin Wallet personal_sign Rejected
     permissions:
       all: allow
 - startRecording: "Native personal_sign Rejected"
+# Press NOT NOW in case the Enabling testing features modal appears
+- runFlow:
+    when:
+      visible: "NOT NOW"
+    commands:
+      - tapOn: "NOT NOW"
 - extendedWaitUntil:
     visible:
       text: "Ethereum_Main"

--- a/.maestro/flows/native/personal_sign_reject.yaml
+++ b/.maestro/flows/native/personal_sign_reject.yaml
@@ -13,9 +13,10 @@ name: Kotlin Dapp to Kotlin Wallet personal_sign Rejected
 - tapOn: "personal_sign"
 - extendedWaitUntil:
     visible:
-      text: "Cancel"
+      id: "wallet-request-reject"
     timeout: 30000
-- tapOn: "Cancel"
+- tapOn:
+    id: "wallet-request-reject"
 - extendedWaitUntil:
     visible:
       text: "result_error"

--- a/.maestro/flows/web/connect_confirm.yaml
+++ b/.maestro/flows/web/connect_confirm.yaml
@@ -9,9 +9,10 @@ name: AppKit Web to Kotlin Wallet Connection Confirmed
 - tapOn: "Kotlin Sample Wallet Kotlin Sample Wallet"
 - extendedWaitUntil:
     visible:
-      text: "Connect"
+      id: "wallet-request-approve"
     timeout: 30000
-- tapOn: "Connect"
+- tapOn:
+    id: "wallet-request-approve"
 - back
 - back
 - assertVisible: "AppKit Interactions"

--- a/.maestro/flows/web/connect_reject.yaml
+++ b/.maestro/flows/web/connect_reject.yaml
@@ -9,9 +9,10 @@ name: AppKit Web to Kotlin Wallet Connection Rejected
 - tapOn: "Kotlin Sample Wallet Kotlin Sample Wallet"
 - extendedWaitUntil:
     visible:
-      text: "Cancel"
+      id: "wallet-request-reject"
     timeout: 30000
-- tapOn: "Cancel"
+- tapOn:
+    id: "wallet-request-reject"
 - back
 - back
 - assertVisible: "Connection declined"

--- a/.maestro/flows/web/sign_request_confirm.yaml
+++ b/.maestro/flows/web/sign_request_confirm.yaml
@@ -9,8 +9,9 @@ name: AppKit Web to Kotlin Wallet Sign Request Confirmed
 - tapOn: "Sign Message"
 - extendedWaitUntil:
     visible:
-      text: "Sign"
+      id: "wallet-request-approve"
     timeout: 30000
-- tapOn: "Sign"
+- tapOn:
+    id: "wallet-request-approve"
 - back
 - assertVisible: "Signing Succeeded"

--- a/.maestro/flows/web/sign_request_reject.yaml
+++ b/.maestro/flows/web/sign_request_reject.yaml
@@ -9,8 +9,9 @@ name: AppKit Web to Kotlin Wallet Sign Request Rejected
 - tapOn: "Sign Message"
 - extendedWaitUntil:
     visible:
-      text: "Cancel"
+      id: "wallet-request-reject"
     timeout: 30000
-- tapOn: "Cancel"
+- tapOn:
+    id: "wallet-request-reject"
 - back
 - assertVisible: "Signing Failed"

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/RequestBottomSheet.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/RequestBottomSheet.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -217,7 +215,6 @@ private fun ModalFooter(
                 .then(
                     if (!buttonsDisabled) Modifier.clickable { onReject() } else Modifier
                 )
-                .semantics { testTagsAsResourceId = true }
                 .testTag("wallet-request-reject"),
             contentAlignment = Alignment.Center
         ) {
@@ -254,7 +251,6 @@ private fun ModalFooter(
                         Modifier
                     }
                 )
-                .semantics { testTagsAsResourceId = true }
                 .testTag("wallet-request-approve"),
             contentAlignment = Alignment.Center
         ) {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/RequestBottomSheet.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/common/RequestBottomSheet.kt
@@ -27,7 +27,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -213,7 +216,9 @@ private fun ModalFooter(
                 )
                 .then(
                     if (!buttonsDisabled) Modifier.clickable { onReject() } else Modifier
-                ),
+                )
+                .semantics { testTagsAsResourceId = true }
+                .testTag("wallet-request-reject"),
             contentAlignment = Alignment.Center
         ) {
             if (isLoadingReject) {
@@ -248,7 +253,9 @@ private fun ModalFooter(
                     } else {
                         Modifier
                     }
-                ),
+                )
+                .semantics { testTagsAsResourceId = true }
+                .testTag("wallet-request-approve"),
             contentAlignment = Alignment.Center
         ) {
             if (isLoadingApprove) {


### PR DESCRIPTION
## Summary
- Dismiss the **NOT NOW** / "Enabling testing features" popup before asserting `Chain selection` in `connect_confirm` / `connect_reject` — this was the first failing assertion on PR #357.
- Add stable testTags `wallet-request-approve` / `wallet-request-reject` to the shared `RequestBottomSheet` footer buttons. Since `RequestBottomSheet` backs SessionProposal, SessionRequest, and SessionAuthenticate dialogs, tagging once covers all three.
- Migrate wallet-side selectors in all 8 maestro flows (4 native, 4 web) from brittle `text:` matchers (`"Connect"`, `"Cancel"`, `"Sign"`) to stable `id:` matchers. dApp-side selectors are unchanged since the dApp sample wasn't refactored.

## Test plan
- [ ] CI: `Run E2E Tests` turns green for all 8 flows
- [ ] `connect_confirm` / `connect_reject` pass even when the testing-features popup appears
- [ ] Wallet-side taps still succeed after any future label tweak (no YAML change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)