### PR TITLE
feat(wallet-sample): support two-action Permit2 payment flow

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentTransactionUtil.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentTransactionUtil.kt
@@ -32,7 +32,10 @@ internal object PaymentTransactionUtil {
     private const val TX_CONFIRMATION_TIMEOUT_MS = 120_000L
     private const val TX_RECEIPT_POLL_INTERVAL_MS = 3_000L
     private const val GAS_ESTIMATION_RPC_TIMEOUT_MS = 15_000L
+    private const val RPC_CALL_TIMEOUT_MS = 30_000L
     private const val POLYGON_CHAIN_ID = "eip155:137"
+    private val GAS_BUFFER_PERCENT = BigInteger.valueOf(120)
+    private val GAS_BUFFER_DIVISOR = BigInteger.valueOf(100)
 
     private val NATIVE_SYMBOL_BY_CHAIN_ID = mapOf(
         "eip155:1" to "ETH",
@@ -93,6 +96,7 @@ internal object PaymentTransactionUtil {
             }
 
             val gasLimit = gasLimitDeferred.await()
+                .multiply(GAS_BUFFER_PERCENT).divide(GAS_BUFFER_DIVISOR)
             val feeData = feeDataDeferred.await()
             val fresh = applyFreshFees(action.chainId, tx, feeData)
             val feePerGas = fresh.maxFeePerGas
@@ -112,36 +116,41 @@ internal object PaymentTransactionUtil {
         val tx = parseTxParam(action.params) ?: error("Invalid eth_sendTransaction params")
         val from = tx.optString("from").ifBlank { EthAccountDelegate.address }
 
-        val feeData = runCatching { fetchFeeData(action.chainId) }
+        val feeData = runCatching { withTimeout(RPC_CALL_TIMEOUT_MS) { fetchFeeData(action.chainId) } }
             .onFailure { Log.w(TAG, "Failed to fetch fresh fees for ${action.chainId}: ${it.message}") }
             .getOrNull()
 
         val baseFresh = if (feeData != null) {
             applyFreshFees(action.chainId, tx, feeData)
         } else {
-            // Fall back to whatever the merchant supplied in the action.
+            // Fresh-fee fetch failed — only proceed if the merchant supplied valid EIP-1559 fees.
+            val merchantMaxFee = parseHexBigInteger(tx.optString("maxFeePerGas"), default = BigInteger.ZERO)
+            val merchantPriorityFee = parseHexBigInteger(tx.optString("maxPriorityFeePerGas"), default = BigInteger.ZERO)
+            if (merchantMaxFee <= BigInteger.ZERO || merchantPriorityFee <= BigInteger.ZERO) {
+                error(
+                    "Failed to fetch fresh fees for ${action.chainId} and transaction is missing valid " +
+                        "maxFeePerGas/maxPriorityFeePerGas"
+                )
+            }
             FreshTx(
                 chainId = action.chainId,
                 to = tx.getString("to"),
                 data = tx.optString("data", "0x").ifBlank { "0x" },
                 value = parseHexBigInteger(tx.optString("value"), default = BigInteger.ZERO),
                 gasLimit = parseTxGasLimit(tx),
-                maxFeePerGas = parseHexBigInteger(tx.optString("maxFeePerGas"), default = BigInteger.ZERO),
-                maxPriorityFeePerGas = parseHexBigInteger(tx.optString("maxPriorityFeePerGas"), default = BigInteger.ZERO),
+                maxFeePerGas = merchantMaxFee,
+                maxPriorityFeePerGas = merchantPriorityFee,
             )
         }
 
-        // Merchants commonly omit gas/gasLimit — estimate it ourselves and add a
-        // 20% buffer so the tx can't fail with `intrinsic gas too low`.
         val fresh = if (baseFresh.gasLimit <= BigInteger.ZERO) {
-            val estimated = rpcEstimateGas(action.chainId, tx, from)
-            val withBuffer = estimated.multiply(BigInteger.valueOf(120)).divide(BigInteger.valueOf(100))
-            baseFresh.copy(gasLimit = withBuffer)
+            val estimated = withTimeout(RPC_CALL_TIMEOUT_MS) { rpcEstimateGas(action.chainId, tx, from) }
+            baseFresh.copy(gasLimit = estimated.multiply(GAS_BUFFER_PERCENT).divide(GAS_BUFFER_DIVISOR))
         } else {
             baseFresh
         }
 
-        val nonce = rpcGetTransactionCount(action.chainId, from)
+        val nonce = withTimeout(RPC_CALL_TIMEOUT_MS) { rpcGetTransactionCount(action.chainId, from) }
 
         val numericChainId = action.chainId.substringAfter(":").toLong()
         val rawTx = RawTransaction.createTransaction(
@@ -158,7 +167,7 @@ internal object PaymentTransactionUtil {
             TransactionEncoder.signMessage(rawTx, Credentials.create(EthAccountDelegate.privateKey))
         )
 
-        return rpcSendRawTransaction(action.chainId, signed)
+        return withTimeout(RPC_CALL_TIMEOUT_MS) { rpcSendRawTransaction(action.chainId, signed) }
     }
 
     /**
@@ -206,14 +215,20 @@ internal object PaymentTransactionUtil {
             val resp = service.sendJsonRpcRequest(
                 JsonRpcRequest(method = "eth_gasPrice", params = emptyList(), id = randomId())
             )
-            (resp.result as? String)?.let { parseHexBigInteger(it, default = BigInteger.ZERO) }
+            if (resp.error != null) error("eth_gasPrice failed: ${resp.error.message}")
+            val gasPriceHex = resp.result as? String
+                ?: error("eth_gasPrice returned null or invalid result")
+            parseHexBigInteger(gasPriceHex, default = BigInteger.ZERO)
         }
         val blockDeferred = async {
             val resp = service.sendJsonRpcRequest(
                 JsonRpcRequest(method = "eth_getBlockByNumber", params = listOf("latest", false), id = randomId())
             )
+            if (resp.error != null) error("eth_getBlockByNumber failed: ${resp.error.message}")
             @Suppress("UNCHECKED_CAST")
-            (resp.result as? Map<String, Any?>)?.get("baseFeePerGas") as? String
+            val block = resp.result as? Map<String, Any?>
+                ?: error("eth_getBlockByNumber returned null or invalid result")
+            block["baseFeePerGas"] as? String
         }
 
         val gasPrice = gasPriceDeferred.await()
@@ -268,7 +283,7 @@ internal object PaymentTransactionUtil {
             .maxOrNull() ?: DEFAULT_PRIORITY_FEE_WEI
 
         val maxFee = listOfNotNull(
-            feeData.baseFeePerGas?.multiply(BigInteger.TWO)?.add(priorityFee),
+            feeData.baseFeePerGas?.multiply(BigInteger.valueOf(2))?.add(priorityFee),
             feeData.gasPrice,
             originalMaxFee.takeIf { it > BigInteger.ZERO },
             priorityFee,

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentTransactionUtil.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentTransactionUtil.kt
@@ -1,0 +1,330 @@
+@file:JvmSynthetic
+
+package com.reown.sample.wallet.payment
+
+import android.util.Log
+import com.reown.sample.wallet.BuildConfig
+import com.reown.sample.wallet.blockchain.JsonRpcRequest
+import com.reown.sample.wallet.blockchain.createBlockChainApiService
+import com.reown.sample.wallet.domain.account.EthAccountDelegate
+import com.reown.walletkit.client.Wallet
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import org.json.JSONArray
+import org.json.JSONObject
+import org.web3j.crypto.Credentials
+import org.web3j.crypto.RawTransaction
+import org.web3j.crypto.TransactionEncoder
+import org.web3j.utils.Convert
+import org.web3j.utils.Numeric
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+
+internal object PaymentTransactionUtil {
+
+    private const val TAG = "PaymentTransactionUtil"
+
+    private val POLYGON_MIN_PRIORITY_FEE_WEI = BigInteger("30000000000") // 30 gwei
+    private val DEFAULT_PRIORITY_FEE_WEI = BigInteger("1500000000")      // 1.5 gwei (ethers.js v5 default)
+    private const val TX_CONFIRMATION_TIMEOUT_MS = 120_000L
+    private const val TX_RECEIPT_POLL_INTERVAL_MS = 3_000L
+    private const val GAS_ESTIMATION_RPC_TIMEOUT_MS = 15_000L
+    private const val POLYGON_CHAIN_ID = "eip155:137"
+
+    private val NATIVE_SYMBOL_BY_CHAIN_ID = mapOf(
+        "eip155:1" to "ETH",
+        "eip155:10" to "ETH",
+        "eip155:11155420" to "ETH",
+        "eip155:42161" to "ETH",
+        "eip155:8453" to "ETH",
+        "eip155:1313161554" to "ETH",
+        "eip155:7777777" to "ETH",
+        "eip155:137" to "POL",
+        "eip155:56" to "BNB",
+        "eip155:43114" to "AVAX",
+        "eip155:43113" to "AVAX",
+        "eip155:250" to "FTM",
+        "eip155:100" to "XDAI",
+        "eip155:9001" to "EVMOS",
+        "eip155:324" to "ETH",
+        "eip155:314" to "FIL",
+        "eip155:4689" to "IOTX",
+        "eip155:1088" to "METIS",
+        "eip155:1284" to "GLMR",
+        "eip155:1285" to "MOVR",
+        "eip155:42220" to "CELO",
+        "eip155:143" to "MON",
+    )
+
+    private data class FeeData(
+        val gasPrice: BigInteger?,
+        val baseFeePerGas: BigInteger?,
+        val maxPriorityFeePerGas: BigInteger,
+        val maxFeePerGas: BigInteger?,
+    )
+
+    private data class FreshTx(
+        val chainId: String,
+        val to: String,
+        val data: String,
+        val value: BigInteger,
+        val gasLimit: BigInteger,
+        val maxFeePerGas: BigInteger,
+        val maxPriorityFeePerGas: BigInteger,
+    )
+
+    /**
+     * Estimate the fee for the given approval action, returning a human-readable
+     * string like `~0.0012 POL` or null if estimation fails.
+     */
+    suspend fun estimateApprovalFee(action: Wallet.Model.WalletRpcAction): String? = runCatching {
+        val tx = parseTxParam(action.params) ?: return null
+        val from = tx.optString("from").ifBlank { EthAccountDelegate.address }
+
+        coroutineScope {
+            val gasLimitDeferred = async {
+                withTimeout(GAS_ESTIMATION_RPC_TIMEOUT_MS) { rpcEstimateGas(action.chainId, tx, from) }
+            }
+            val feeDataDeferred = async {
+                withTimeout(GAS_ESTIMATION_RPC_TIMEOUT_MS) { fetchFeeData(action.chainId) }
+            }
+
+            val gasLimit = gasLimitDeferred.await()
+            val feeData = feeDataDeferred.await()
+            val fresh = applyFreshFees(action.chainId, tx, feeData)
+            val feePerGas = fresh.maxFeePerGas
+
+            formatGasEstimate(gasLimit.multiply(feePerGas), action.chainId)
+        }
+    }.getOrElse { error ->
+        Log.w(TAG, "estimateApprovalFee failed for ${action.chainId}: ${error.message}")
+        null
+    }
+
+    /**
+     * Sign and broadcast `eth_sendTransaction` with freshly fetched fee data.
+     * Returns the transaction hash. The caller is responsible for awaiting confirmation.
+     */
+    suspend fun sendTransactionWithFreshFees(action: Wallet.Model.WalletRpcAction): String {
+        val tx = parseTxParam(action.params) ?: error("Invalid eth_sendTransaction params")
+        val from = tx.optString("from").ifBlank { EthAccountDelegate.address }
+
+        val feeData = runCatching { fetchFeeData(action.chainId) }
+            .onFailure { Log.w(TAG, "Failed to fetch fresh fees for ${action.chainId}: ${it.message}") }
+            .getOrNull()
+
+        val baseFresh = if (feeData != null) {
+            applyFreshFees(action.chainId, tx, feeData)
+        } else {
+            // Fall back to whatever the merchant supplied in the action.
+            FreshTx(
+                chainId = action.chainId,
+                to = tx.getString("to"),
+                data = tx.optString("data", "0x").ifBlank { "0x" },
+                value = parseHexBigInteger(tx.optString("value"), default = BigInteger.ZERO),
+                gasLimit = parseTxGasLimit(tx),
+                maxFeePerGas = parseHexBigInteger(tx.optString("maxFeePerGas"), default = BigInteger.ZERO),
+                maxPriorityFeePerGas = parseHexBigInteger(tx.optString("maxPriorityFeePerGas"), default = BigInteger.ZERO),
+            )
+        }
+
+        // Merchants commonly omit gas/gasLimit — estimate it ourselves and add a
+        // 20% buffer so the tx can't fail with `intrinsic gas too low`.
+        val fresh = if (baseFresh.gasLimit <= BigInteger.ZERO) {
+            val estimated = rpcEstimateGas(action.chainId, tx, from)
+            val withBuffer = estimated.multiply(BigInteger.valueOf(120)).divide(BigInteger.valueOf(100))
+            baseFresh.copy(gasLimit = withBuffer)
+        } else {
+            baseFresh
+        }
+
+        val nonce = rpcGetTransactionCount(action.chainId, from)
+
+        val numericChainId = action.chainId.substringAfter(":").toLong()
+        val rawTx = RawTransaction.createTransaction(
+            numericChainId,
+            nonce,
+            fresh.gasLimit,
+            fresh.to,
+            fresh.value,
+            fresh.data,
+            fresh.maxPriorityFeePerGas,
+            fresh.maxFeePerGas,
+        )
+        val signed = Numeric.toHexString(
+            TransactionEncoder.signMessage(rawTx, Credentials.create(EthAccountDelegate.privateKey))
+        )
+
+        return rpcSendRawTransaction(action.chainId, signed)
+    }
+
+    /**
+     * Poll `eth_getTransactionReceipt` until the transaction has at least one confirmation
+     * or the timeout elapses.
+     */
+    suspend fun waitForTransactionConfirmation(
+        chainId: String,
+        txHash: String,
+        timeoutMs: Long = TX_CONFIRMATION_TIMEOUT_MS,
+    ) {
+        withTimeout(timeoutMs) {
+            while (true) {
+                val receipt = rpcGetTransactionReceipt(chainId, txHash)
+                if (receipt != null) {
+                    val status = receipt.optString("status")
+                    if (status == "0x0") error("Transaction $txHash reverted on chain $chainId")
+                    return@withTimeout
+                }
+                delay(TX_RECEIPT_POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    // ---- RPC helpers --------------------------------------------------------
+
+    private suspend fun rpcEstimateGas(chainId: String, tx: JSONObject, from: String): BigInteger {
+        val callObject = JSONObject().apply {
+            put("from", from)
+            tx.optString("to").takeIf { it.isNotBlank() }?.let { put("to", it) }
+            tx.optString("data").takeIf { it.isNotBlank() }?.let { put("data", it) }
+            tx.optString("value").takeIf { it.isNotBlank() }?.let { put("value", it) }
+        }
+        val service = createBlockChainApiService(BuildConfig.PROJECT_ID, chainId)
+        val response = service.sendJsonRpcRequest(
+            JsonRpcRequest(method = "eth_estimateGas", params = listOf(callObject.toMap()), id = randomId())
+        )
+        if (response.error != null) error("eth_estimateGas failed: ${response.error.message}")
+        return parseHexBigInteger(response.result as? String, default = BigInteger.ZERO)
+    }
+
+    private suspend fun fetchFeeData(chainId: String): FeeData = coroutineScope {
+        val service = createBlockChainApiService(BuildConfig.PROJECT_ID, chainId)
+        val gasPriceDeferred = async {
+            val resp = service.sendJsonRpcRequest(
+                JsonRpcRequest(method = "eth_gasPrice", params = emptyList(), id = randomId())
+            )
+            (resp.result as? String)?.let { parseHexBigInteger(it, default = BigInteger.ZERO) }
+        }
+        val blockDeferred = async {
+            val resp = service.sendJsonRpcRequest(
+                JsonRpcRequest(method = "eth_getBlockByNumber", params = listOf("latest", false), id = randomId())
+            )
+            @Suppress("UNCHECKED_CAST")
+            (resp.result as? Map<String, Any?>)?.get("baseFeePerGas") as? String
+        }
+
+        val gasPrice = gasPriceDeferred.await()
+        val baseFee = blockDeferred.await()?.let { parseHexBigInteger(it, default = BigInteger.ZERO) }
+
+        FeeData(
+            gasPrice = gasPrice,
+            baseFeePerGas = baseFee,
+            maxPriorityFeePerGas = DEFAULT_PRIORITY_FEE_WEI,
+            maxFeePerGas = null,
+        )
+    }
+
+    private suspend fun rpcGetTransactionCount(chainId: String, from: String): BigInteger {
+        val service = createBlockChainApiService(BuildConfig.PROJECT_ID, chainId)
+        val response = service.sendJsonRpcRequest(
+            JsonRpcRequest(method = "eth_getTransactionCount", params = listOf(from, "pending"), id = randomId())
+        )
+        if (response.error != null) error("eth_getTransactionCount failed: ${response.error.message}")
+        return parseHexBigInteger(response.result as? String, default = BigInteger.ZERO)
+    }
+
+    private suspend fun rpcSendRawTransaction(chainId: String, signedTx: String): String {
+        val service = createBlockChainApiService(BuildConfig.PROJECT_ID, chainId)
+        val response = service.sendJsonRpcRequest(
+            JsonRpcRequest(method = "eth_sendRawTransaction", params = listOf(signedTx), id = randomId())
+        )
+        if (response.error != null) error("eth_sendRawTransaction failed: ${response.error.message}")
+        return response.result as? String ?: error("eth_sendRawTransaction returned no result")
+    }
+
+    private suspend fun rpcGetTransactionReceipt(chainId: String, txHash: String): JSONObject? {
+        val service = createBlockChainApiService(BuildConfig.PROJECT_ID, chainId)
+        val response = service.sendJsonRpcRequest(
+            JsonRpcRequest(method = "eth_getTransactionReceipt", params = listOf(txHash), id = randomId())
+        )
+        if (response.error != null) error("eth_getTransactionReceipt failed: ${response.error.message}")
+        @Suppress("UNCHECKED_CAST")
+        val map = response.result as? Map<String, Any?> ?: return null
+        return JSONObject(map)
+    }
+
+    // ---- Fee math -----------------------------------------------------------
+
+    private fun applyFreshFees(chainId: String, originalTx: JSONObject, feeData: FeeData): FreshTx {
+        val chainFloor = if (chainId == POLYGON_CHAIN_ID) POLYGON_MIN_PRIORITY_FEE_WEI else null
+        val originalMaxPriority = parseHexBigInteger(originalTx.optString("maxPriorityFeePerGas"), default = BigInteger.ZERO)
+        val originalMaxFee = parseHexBigInteger(originalTx.optString("maxFeePerGas"), default = BigInteger.ZERO)
+        val originalGasLimit = parseTxGasLimit(originalTx)
+
+        val priorityFee = listOfNotNull(chainFloor, feeData.maxPriorityFeePerGas, originalMaxPriority.takeIf { it > BigInteger.ZERO })
+            .maxOrNull() ?: DEFAULT_PRIORITY_FEE_WEI
+
+        val maxFee = listOfNotNull(
+            feeData.baseFeePerGas?.multiply(BigInteger.TWO)?.add(priorityFee),
+            feeData.gasPrice,
+            originalMaxFee.takeIf { it > BigInteger.ZERO },
+            priorityFee,
+        ).maxOrNull() ?: priorityFee
+
+        return FreshTx(
+            chainId = chainId,
+            to = originalTx.getString("to"),
+            data = originalTx.optString("data", "0x").ifBlank { "0x" },
+            value = parseHexBigInteger(originalTx.optString("value"), default = BigInteger.ZERO),
+            gasLimit = originalGasLimit,
+            maxFeePerGas = maxFee,
+            maxPriorityFeePerGas = priorityFee,
+        )
+    }
+
+    private fun formatGasEstimate(totalFeeWei: BigInteger, chainId: String): String {
+        val symbol = NATIVE_SYMBOL_BY_CHAIN_ID[chainId] ?: "ETH"
+        val ether = Convert.fromWei(BigDecimal(totalFeeWei), Convert.Unit.ETHER)
+        if (ether <= BigDecimal.ZERO) return "~$ether $symbol"
+        val scale = if (ether >= BigDecimal("0.01")) 4 else 6
+        val rounded = ether.setScale(scale, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString()
+        return "~$rounded $symbol"
+    }
+
+    // ---- Parsing helpers ----------------------------------------------------
+
+    private fun parseTxParam(paramsJson: String): JSONObject? = runCatching {
+        val arr = JSONArray(paramsJson)
+        if (arr.length() == 0) null else arr.getJSONObject(0)
+    }.getOrNull()
+
+    private fun parseTxGasLimit(tx: JSONObject): BigInteger {
+        // EIP-1474 uses `gas`; some merchants emit `gasLimit`.
+        val gas = parseHexBigInteger(tx.optString("gas"), default = BigInteger.ZERO)
+        if (gas > BigInteger.ZERO) return gas
+        return parseHexBigInteger(tx.optString("gasLimit"), default = BigInteger.ZERO)
+    }
+
+    private fun parseHexBigInteger(value: String?, default: BigInteger): BigInteger {
+        if (value.isNullOrBlank()) return default
+        val trimmed = value.trim()
+        return runCatching {
+            if (trimmed.startsWith("0x") || trimmed.startsWith("0X")) {
+                BigInteger(Numeric.cleanHexPrefix(trimmed), 16)
+            } else {
+                BigInteger(trimmed)
+            }
+        }.getOrDefault(default)
+    }
+
+    private fun JSONObject.toMap(): Map<String, Any?> {
+        val result = mutableMapOf<String, Any?>()
+        keys().forEach { key -> result[key] = get(key) }
+        return result
+    }
+
+    private fun randomId(): Int = (100..9_999).random()
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentUtil.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/payment/PaymentUtil.kt
@@ -1,0 +1,23 @@
+@file:JvmSynthetic
+
+package com.reown.sample.wallet.payment
+
+import com.reown.walletkit.client.Wallet
+
+internal object PaymentUtil {
+
+    private const val ETH_SEND_TRANSACTION = "eth_sendTransaction"
+
+    data class PaymentContext(
+        val approvalAction: Wallet.Model.RequiredAction.WalletRpc?,
+    ) {
+        val requiresApproval: Boolean get() = approvalAction != null
+    }
+
+    fun getPaymentContext(actions: List<Wallet.Model.RequiredAction>?): PaymentContext {
+        val approval = actions
+            ?.filterIsInstance<Wallet.Model.RequiredAction.WalletRpc>()
+            ?.firstOrNull { it.action.method == ETH_SEND_TRANSACTION }
+        return PaymentContext(approvalAction = approval)
+    }
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -408,15 +408,6 @@ private fun PaymentOptionCard(
     }
 }
 
-/**
- * Displays a token icon with a network icon badge in the bottom-right corner.
- */
-/**
- * Renders the token icon with optional network badge. Falls back to:
- *  - the network icon (if the token icon is missing), or
- *  - a circle with the symbol's first letter (if both are missing).
- * Native assets often come without an explicit token iconUrl.
- */
 @Composable
 private fun PaymentAssetIcon(
     display: Wallet.Model.PaymentAmountDisplay?,
@@ -455,7 +446,7 @@ private fun PaymentAssetIcon(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = symbol.take(1).uppercase(),
+                text = symbol.take(1).uppercase(Locale.ROOT),
                 style = WCTheme.typography.bodyLgMedium.copy(color = WCTheme.colors.textPrimary)
             )
         }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -145,6 +145,9 @@ fun PaymentRoute(
                 SummaryContent(
                     paymentInfo = state.paymentInfo,
                     selectedOption = state.selectedOption,
+                    requiresApproval = state.requiresApproval,
+                    approvalGasEstimate = state.approvalGasEstimate,
+                    isEstimatingApprovalGas = state.isEstimatingApprovalGas,
                     onConfirm = { viewModel.confirmFromSummary() },
                     onClose = {
                         viewModel.cancel()
@@ -352,25 +355,21 @@ private fun PaymentOptionCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                // Asset icon with network badge
-                option.amount.display?.iconUrl?.let { iconUrl ->
-                    val networkBadgeStrokeColor = if (isSelected) {
-                        WCTheme.colors.foregroundAccentPrimary10Solid
-                    } else {
-                        WCTheme.colors.foregroundPrimary
-                    }
-
-                    TokenIconWithNetwork(
-                        tokenIconUrl = iconUrl,
-                        networkIconUrl = option.amount.display?.networkIconUrl,
-                        tokenIconSize = 40.dp,
-                        networkIconSize = 16.dp,
-                        networkIconBorderWidth = 2.dp,
-                        networkIconBorderColor = networkBadgeStrokeColor,
-                        useExternalNetworkBorder = true
-                    )
-                    Spacer(modifier = Modifier.width(WCTheme.spacing.spacing3))
+                val networkBadgeStrokeColor = if (isSelected) {
+                    WCTheme.colors.foregroundAccentPrimary10Solid
+                } else {
+                    WCTheme.colors.foregroundPrimary
                 }
+
+                PaymentAssetIcon(
+                    display = option.amount.display,
+                    tokenIconSize = 40.dp,
+                    networkIconSize = 16.dp,
+                    networkIconBorderWidth = 2.dp,
+                    networkIconBorderColor = networkBadgeStrokeColor,
+                    useExternalNetworkBorder = true
+                )
+                Spacer(modifier = Modifier.width(WCTheme.spacing.spacing3))
 
                 // Token amount
                 val display = option.amount.display
@@ -412,6 +411,57 @@ private fun PaymentOptionCard(
 /**
  * Displays a token icon with a network icon badge in the bottom-right corner.
  */
+/**
+ * Renders the token icon with optional network badge. Falls back to:
+ *  - the network icon (if the token icon is missing), or
+ *  - a circle with the symbol's first letter (if both are missing).
+ * Native assets often come without an explicit token iconUrl.
+ */
+@Composable
+private fun PaymentAssetIcon(
+    display: Wallet.Model.PaymentAmountDisplay?,
+    tokenIconSize: Dp,
+    networkIconSize: Dp,
+    networkIconBorderWidth: Dp = 2.dp,
+    networkIconBorderColor: Color = Color.White,
+    useExternalNetworkBorder: Boolean = false
+) {
+    val tokenIconUrl = display?.iconUrl?.takeIf { it.isNotBlank() }
+    val networkIconUrl = display?.networkIconUrl?.takeIf { it.isNotBlank() }
+    val symbol = display?.assetSymbol ?: "?"
+
+    when {
+        tokenIconUrl != null -> TokenIconWithNetwork(
+            tokenIconUrl = tokenIconUrl,
+            networkIconUrl = networkIconUrl,
+            tokenIconSize = tokenIconSize,
+            networkIconSize = networkIconSize,
+            networkIconBorderWidth = networkIconBorderWidth,
+            networkIconBorderColor = networkIconBorderColor,
+            useExternalNetworkBorder = useExternalNetworkBorder
+        )
+        networkIconUrl != null -> AsyncImage(
+            model = networkIconUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(tokenIconSize)
+                .clip(CircleShape)
+        )
+        else -> Box(
+            modifier = Modifier
+                .size(tokenIconSize)
+                .clip(CircleShape)
+                .background(WCTheme.colors.foregroundTertiary),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = symbol.take(1).uppercase(),
+                style = WCTheme.typography.bodyLgMedium.copy(color = WCTheme.colors.textPrimary)
+            )
+        }
+    }
+}
+
 @Composable
 private fun TokenIconWithNetwork(
     tokenIconUrl: String,
@@ -520,6 +570,9 @@ private fun PaymentTitle(paymentInfo: Wallet.Model.PaymentInfo?) {
 private fun SummaryContent(
     paymentInfo: Wallet.Model.PaymentInfo?,
     selectedOption: Wallet.Model.PaymentOption,
+    requiresApproval: Boolean,
+    approvalGasEstimate: String?,
+    isEstimatingApprovalGas: Boolean,
     onConfirm: () -> Unit,
     onClose: () -> Unit
 ) {
@@ -586,16 +639,44 @@ private fun SummaryContent(
 
                 Spacer(modifier = Modifier.width(WCTheme.spacing.spacing2))
 
-                display?.iconUrl?.let { iconUrl ->
-                    TokenIconWithNetwork(
-                        tokenIconUrl = iconUrl,
-                        networkIconUrl = display.networkIconUrl,
-                        tokenIconSize = 32.dp,
-                        networkIconSize = 16.dp,
-                        networkIconBorderWidth = 2.dp,
-                        networkIconBorderColor = WCTheme.colors.foregroundPrimary
-                    )
-                }
+                PaymentAssetIcon(
+                    display = display,
+                    tokenIconSize = 32.dp,
+                    networkIconSize = 16.dp,
+                    networkIconBorderWidth = 2.dp,
+                    networkIconBorderColor = WCTheme.colors.foregroundPrimary
+                )
+            }
+        }
+
+        if (requiresApproval) {
+            Spacer(modifier = Modifier.height(WCTheme.spacing.spacing2))
+
+            val feeText = when {
+                isEstimatingApprovalGas -> "Loading..."
+                approvalGasEstimate != null -> approvalGasEstimate
+                else -> "Network fee set by wallet"
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(68.dp)
+                    .clip(WCTheme.borderRadius.shapeLarge)
+                    .background(WCTheme.colors.foregroundPrimary)
+                    .testTag("pay-review-one-time-fee")
+                    .padding(horizontal = WCTheme.spacing.spacing4),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "One-time fee",
+                    style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textTertiary)
+                )
+                Text(
+                    text = feeText,
+                    style = WCTheme.typography.bodyLgMedium.copy(color = WCTheme.colors.textPrimary)
+                )
             }
         }
 
@@ -735,10 +816,15 @@ private fun formatTokenAmount(value: String, decimals: Int, symbol: String): Str
         val rawValue = BigDecimal(value)
         val safeDecimals = decimals.coerceIn(0, 18)
         val divisor = BigDecimal.TEN.pow(safeDecimals)
-        val formattedValue = rawValue.divide(divisor, 4, RoundingMode.HALF_UP)
-            .stripTrailingZeros()
-            .toPlainString()
-        val formatted = java.text.NumberFormat.getNumberInstance(Locale.US).format(BigDecimal(formattedValue))
+        val tokenValue = rawValue.divide(divisor, safeDecimals, RoundingMode.HALF_UP)
+        if (tokenValue.signum() == 0) return "0 $symbol"
+
+        // Non-zero values that would round to 0.0000 at 4 decimals (e.g. 0.0000123 ETH)
+        // get a "<0.0001" treatment so the user sees the amount is non-trivial.
+        val rounded = tokenValue.setScale(4, RoundingMode.HALF_UP).stripTrailingZeros()
+        if (rounded.signum() == 0) return "<0.0001 $symbol"
+
+        val formatted = java.text.NumberFormat.getNumberInstance(Locale.US).format(rounded)
         "$formatted $symbol"
     } catch (e: Exception) {
         "$value $symbol"
@@ -784,7 +870,7 @@ private fun ProcessingContent(
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
 
         Text(
-            text = "Confirming your payment...",
+            text = message,
             style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary),
             textAlign = TextAlign.Center,
             modifier = Modifier.testTag("pay-loading-message")

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.reown.sample.wallet.domain.WalletKitDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.nfc.PaymentSigner
+import com.reown.sample.wallet.payment.PaymentTransactionUtil
+import com.reown.sample.wallet.payment.PaymentUtil
 import com.reown.walletkit.client.Wallet
 import com.reown.walletkit.client.WalletKit
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +20,6 @@ import android.net.Uri
 import android.util.Base64
 import android.util.Log
 import com.reown.sample.wallet.ui.routes.dialog_routes.payment.PaymentUiState.*
-import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -39,7 +41,12 @@ class PaymentViewModel : ViewModel() {
 
     // Information Capture state
     private var pendingWalletRpcActions: List<Wallet.Model.RequiredAction.WalletRpc> = emptyList()
+    private var pendingWalletRpcActionsKey: RequiredActionsKey? = null
     private val collectedValues: MutableMap<String, String> = mutableMapOf()
+
+    // Race-safe sequencing for background action fetch + gas estimate
+    private var paymentActionsRequestSeq: Long = 0
+    private var pendingActionsJob: Job? = null
 
     init {
         // Collect payment options event (has replay=1 to ensure we receive it even if emitted before collecting)
@@ -55,6 +62,7 @@ class PaymentViewModel : ViewModel() {
     private fun processPaymentOptionsResponse(response: Wallet.Model.PaymentOptionsResponse) {
         // Clear replay cache immediately after consuming to prevent stale data leaking to other ViewModel instances
         WalletKitDelegate.clearPaymentOptions()
+        invalidateRequiredActionsState()
         currentPaymentId = response.paymentId
         collectedValues.clear()
 
@@ -85,6 +93,7 @@ class PaymentViewModel : ViewModel() {
                 paymentInfo = storedPaymentInfo,
                 selectedOption = option
             )
+            fetchPaymentActionsInBackground(option)
         } else {
             _uiState.value = PaymentUiState.Options(
                 paymentLink = currentPaymentLink ?: "",
@@ -99,6 +108,7 @@ class PaymentViewModel : ViewModel() {
      */
     fun setPaymentLink(paymentLink: String) {
         if (currentPaymentLink == paymentLink) return
+        invalidateRequiredActionsState()
         currentPaymentLink = paymentLink
         _uiState.value = PaymentUiState.Loading
         fetchPaymentOptions(paymentLink)
@@ -140,6 +150,7 @@ class PaymentViewModel : ViewModel() {
         val schema = collectData?.schema
 
         if (url != null) {
+            clearRequiredActionsCache()
             // WebView-based IC with per-option URL
             val urlWithPrefill = buildUrlWithPrefill(url, schema)
             _uiState.value = PaymentUiState.WebViewDataCollection(
@@ -147,12 +158,73 @@ class PaymentViewModel : ViewModel() {
                 paymentInfo = storedPaymentInfo
             )
         } else {
-            // No IC required, show review/summary screen
+            // No IC required — render Summary immediately, fetch actions in background
             _uiState.value = PaymentUiState.Summary(
                 paymentInfo = storedPaymentInfo,
                 selectedOption = option
             )
+            fetchPaymentActionsInBackground(option)
         }
+    }
+
+    /**
+     * Fetch required payment actions asynchronously and, if an approval action is
+     * present, kick off a gas estimate so the Summary screen can show the
+     * one-time fee. A request sequence + Job cancellation guard prevents stale
+     * results from leaking into a different option selection.
+     */
+    private fun fetchPaymentActionsInBackground(option: Wallet.Model.PaymentOption) {
+        pendingActionsJob?.cancel()
+        val seq = ++paymentActionsRequestSeq
+        val paymentId = currentPaymentId ?: return
+        val requestKey = RequiredActionsKey(paymentId, option.id)
+        clearRequiredActionsCache()
+        pendingActionsJob = viewModelScope.launch {
+            val result = WalletKit.Pay.getRequiredPaymentActions(
+                Wallet.Params.RequiredPaymentActions(
+                    paymentId = paymentId,
+                    optionId = option.id
+                )
+            )
+            if (!isCurrentRequest(seq, option.id)) return@launch
+            result.fold(
+                onSuccess = { actions ->
+                    pendingWalletRpcActions = actions.filterIsInstance<Wallet.Model.RequiredAction.WalletRpc>()
+                    pendingWalletRpcActionsKey = requestKey
+                    val ctx = PaymentUtil.getPaymentContext(actions)
+                    updateSummary { it.copy(requiresApproval = ctx.requiresApproval) }
+
+                    if (ctx.approvalAction != null) {
+                        updateSummary { it.copy(isEstimatingApprovalGas = true) }
+                        val estimate = runCatching {
+                            PaymentTransactionUtil.estimateApprovalFee(ctx.approvalAction.action)
+                        }.getOrNull()
+                        if (isCurrentRequest(seq, option.id)) {
+                            updateSummary {
+                                it.copy(
+                                    approvalGasEstimate = estimate,
+                                    isEstimatingApprovalGas = false
+                                )
+                            }
+                        }
+                    }
+                },
+                onFailure = { error ->
+                    clearRequiredActionsCache()
+                    Log.w("PaymentViewModel", "Background action fetch failed: ${error.message}")
+                    // Don't surface the error yet — confirmFromSummary will retry and
+                    // show an Error state if the fetch still fails at confirmation time.
+                }
+            )
+        }
+    }
+
+    private fun isCurrentRequest(seq: Long, optionId: String): Boolean =
+        seq == paymentActionsRequestSeq && selectedOptionId == optionId
+
+    private inline fun updateSummary(transform: (PaymentUiState.Summary) -> PaymentUiState.Summary) {
+        val current = _uiState.value as? PaymentUiState.Summary ?: return
+        _uiState.value = transform(current)
     }
 
     /**
@@ -234,16 +306,29 @@ class PaymentViewModel : ViewModel() {
     }
 
     /**
-     * Process payment with the selected option.
-     * Uses WalletKit.Pay for getting required actions.
+     * Process payment with the selected option. If a background action fetch was
+     * already kicked off (from `onOptionSelected` / `onICWebViewComplete`), we
+     * wait for it to finish so the Summary's gas estimate and `pendingWalletRpcActions`
+     * are already populated. Otherwise we fetch actions synchronously here.
      */
     fun processPayment(optionId: String) {
         val paymentId = currentPaymentId ?: return
+        val requestKey = RequiredActionsKey(paymentId, optionId)
         selectedOptionId = optionId
-        _uiState.value = PaymentUiState.Processing("Getting required actions...")
+        _uiState.value = PaymentUiState.Processing(
+            message = "Getting required actions...",
+            paymentInfo = storedPaymentInfo
+        )
 
         viewModelScope.launch {
-            // Get required payment actions using WalletKit.Pay
+            // If a background fetch is in flight, wait for it before executing.
+            pendingActionsJob?.join()
+
+            if (pendingWalletRpcActionsKey == requestKey) {
+                executePayment()
+                return@launch
+            }
+
             val actionsResult = WalletKit.Pay.getRequiredPaymentActions(
                 Wallet.Params.RequiredPaymentActions(
                     paymentId = paymentId,
@@ -252,9 +337,12 @@ class PaymentViewModel : ViewModel() {
             )
             actionsResult.fold(
                 onSuccess = { actions ->
-                    processActions(paymentId, optionId, actions)
+                    pendingWalletRpcActions = actions.filterIsInstance<Wallet.Model.RequiredAction.WalletRpc>()
+                    pendingWalletRpcActionsKey = requestKey
+                    executePayment()
                 },
                 onFailure = { error ->
+                    clearRequiredActionsCache()
                     _uiState.value = PaymentUiState.Error(
                         error.message ?: "Failed to get payment actions",
                         categorizeError(error.message)
@@ -262,18 +350,6 @@ class PaymentViewModel : ViewModel() {
                 }
             )
         }
-    }
-
-    private suspend fun processActions(
-        paymentId: String,
-        optionId: String,
-        actions: List<Wallet.Model.RequiredAction>
-    ) {
-        // Store WalletRpc actions for signing
-        pendingWalletRpcActions = actions.filterIsInstance<Wallet.Model.RequiredAction.WalletRpc>()
-
-        // Information capture already done before options, proceed directly to payment
-        executePayment()
     }
 
     /**
@@ -298,6 +374,7 @@ class PaymentViewModel : ViewModel() {
             paymentInfo = storedPaymentInfo,
             selectedOption = option
         )
+        fetchPaymentActionsInBackground(option)
     }
 
     /**
@@ -308,11 +385,22 @@ class PaymentViewModel : ViewModel() {
     }
 
     /**
-     * Confirm payment from the Summary screen.
+     * Confirm payment from the Summary screen. Runs a local expiry guard with a
+     * 10s safety margin so we don't racily submit an effectively-expired payment.
      */
     fun confirmFromSummary() {
         val optionId = selectedOptionId ?: return
+        if (isPaymentExpiredLocally()) {
+            _uiState.value = PaymentUiState.Error("Payment expired", PaymentErrorType.EXPIRED)
+            return
+        }
         processPayment(optionId)
+    }
+
+    private fun isPaymentExpiredLocally(): Boolean {
+        val expiresAtSeconds = storedPaymentInfo?.expiresAt ?: return false
+        val expiresAtMs = expiresAtSeconds * 1000L
+        return expiresAtMs <= System.currentTimeMillis() + PAY_EXPIRY_GUARD_MS
     }
 
     /**
@@ -333,11 +421,18 @@ class PaymentViewModel : ViewModel() {
 
     /**
      * Execute the payment with collected data and signatures.
-     * Uses WalletKit.Pay for confirming payment.
+     *
+     * Iterates `pendingWalletRpcActions` in order and dispatches each one:
+     *  - `eth_sendTransaction` → broadcast via `PaymentTransactionUtil` with fresh
+     *    gas fees, then wait for confirmation. Not added to `signatures`.
+     *  - `eth_signTypedData_*` / `personal_sign` → signed via `PaymentSigner`
+     *    and appended to `signatures`.
+     * Only typed-data signatures are passed to `confirmPayment`.
      */
     private suspend fun executePayment() {
         val paymentId = currentPaymentId ?: return
         val optionId = selectedOptionId ?: return
+        val symbol = storedPaymentOptions.find { it.id == optionId }?.amount?.display?.assetSymbol ?: "token"
 
         _uiState.value = PaymentUiState.Processing(
             message = "Confirming your payment...",
@@ -345,9 +440,26 @@ class PaymentViewModel : ViewModel() {
         )
 
         try {
-            // Sign all WalletRpc actions and collect signatures
-            val signatures = pendingWalletRpcActions.map { action ->
-                signWalletRpcAction(action.action)
+            val signatures = mutableListOf<String>()
+            for (action in pendingWalletRpcActions) {
+                when (action.action.method) {
+                    ETH_SEND_TRANSACTION -> {
+                        _uiState.value = PaymentUiState.Processing(
+                            message = "Setting up $symbol for the first time...",
+                            paymentInfo = storedPaymentInfo
+                        )
+                        val txHash = PaymentTransactionUtil.sendTransactionWithFreshFees(action.action)
+                        Log.d("PaymentViewModel", "Approval tx broadcast: $txHash")
+                        PaymentTransactionUtil.waitForTransactionConfirmation(action.action.chainId, txHash)
+                        _uiState.value = PaymentUiState.Processing(
+                            message = "Finalizing your payment...",
+                            paymentInfo = storedPaymentInfo
+                        )
+                    }
+                    else -> {
+                        signatures.add(PaymentSigner.signWalletRpcAction(action.action))
+                    }
+                }
             }
 
             // Convert collected data to field results
@@ -420,13 +532,6 @@ class PaymentViewModel : ViewModel() {
     }
 
     /**
-     * Sign a wallet RPC action and return the signature string.
-     * Delegates to shared PaymentSigner utility.
-     */
-    private fun signWalletRpcAction(action: Wallet.Model.WalletRpcAction): String =
-        PaymentSigner.signWalletRpcAction(action)
-
-    /**
      * Categorize an error message into a PaymentErrorType.
      */
     private fun categorizeError(message: String?): PaymentErrorType {
@@ -444,17 +549,39 @@ class PaymentViewModel : ViewModel() {
      * Cancel and reset the payment flow.
      */
     fun cancel() {
+        invalidateRequiredActionsState()
         currentPaymentLink = null
         currentPaymentId = null
         selectedOptionId = null
         storedPaymentInfo = null
         storedPaymentOptions = emptyList()
-        pendingWalletRpcActions = emptyList()
         collectedValues.clear()
         // Don't set state to Loading here - we're navigating away anyway
         // and it causes a brief flash of the loading screen
         // Clear replay cache to prevent stale data on next payment
         WalletKitDelegate.clearPaymentOptions()
+    }
+
+    private companion object {
+        private const val PAY_EXPIRY_GUARD_MS = 10_000L
+        private const val ETH_SEND_TRANSACTION = "eth_sendTransaction"
+    }
+
+    private data class RequiredActionsKey(
+        val paymentId: String,
+        val optionId: String,
+    )
+
+    private fun invalidateRequiredActionsState() {
+        pendingActionsJob?.cancel()
+        pendingActionsJob = null
+        paymentActionsRequestSeq++
+        clearRequiredActionsCache()
+    }
+
+    private fun clearRequiredActionsCache() {
+        pendingWalletRpcActions = emptyList()
+        pendingWalletRpcActionsKey = null
     }
 }
 
@@ -484,7 +611,10 @@ sealed class PaymentUiState {
      */
     data class Summary(
         val paymentInfo: Wallet.Model.PaymentInfo?,
-        val selectedOption: Wallet.Model.PaymentOption
+        val selectedOption: Wallet.Model.PaymentOption,
+        val requiresApproval: Boolean = false,
+        val approvalGasEstimate: String? = null,
+        val isEstimatingApprovalGas: Boolean = false
     ) : PaymentUiState()
 
     /**


### PR DESCRIPTION
## Summary
- Port RN PRs [#472](https://github.com/reown-com/react-native-examples/pull/472) and [#474](https://github.com/reown-com/react-native-examples/pull/474) to the Kotlin wallet sample so it can handle the Permit2 two-action flow (on-chain `eth_sendTransaction` approval + `eth_signTypedData_v4`) and the deprecated-chain cleanup.
- Add `PaymentTransactionUtil` (gas estimation, EIP-1559 fee floors, receipt polling) and `PaymentUtil` (detection of approval-required actions). Wire them into `PaymentViewModel` with a race-safe request sequence, 10s local expiry guard, and progressive loader messages ("Setting up <symbol>..." → "Confirming..." → "Finalizing...").
- Surface the one-time approval fee on the Summary screen (`pay-review-one-time-fee` testTag) with `Loading...` / `~<amount> <SYMBOL>` / `Network fee set by wallet` states. Fix the "0 <SYM>" display for tiny amounts (shows `<0.0001 SYM`) and add a token-icon fallback chain (token → network → first-letter circle).
- When merchant tx params omit `gas`/`gasLimit`, call `eth_estimateGas` with a 20% buffer to avoid `intrinsic gas too low` reverts. Use POL (not MATIC) for Polygon.

## Test plan
- [ ] `./gradlew :sample:wallet:assembleDebug` builds clean
- [ ] Fresh ERC-20 on Polygon: scan link → Summary shows `One-time fee · ~X POL` after brief `Loading...` → Pay broadcasts approve tx → on receipt, typed-data sign → success
- [ ] Same token second time: Summary omits the One-time fee row (no approval action returned)
- [ ] Rapidly switch between two options on the Options screen — only the latest selected option's estimate renders on Summary
- [ ] Pause on Summary until `expiresAt` is within 10s → tap Pay → `EXPIRED` error, no RPC call
- [ ] Native ETH token with tiny amount renders `<0.0001 ETH` with a fallback icon
- [ ] `APP_ID=com.reown.sample.wallet.debug ./scripts/run-maestro-pay-tests.sh` — no regressions on non-approval flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)