### PR TITLE
feat(pos): emit DeclinedUser error for declined_user API response

### DIFF
--- a/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
@@ -60,6 +60,7 @@ object Pos {
             data class PaymentNotFound(val message: String) : PaymentError
             data class PaymentExpired(val message: String) : PaymentError
             data class InvalidPaymentRequest(val message: String) : PaymentError
+            data object SanctionedUser : PaymentError
             data class Undefined(val message: String) : PaymentError
         }
     }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/Pos.kt
@@ -60,7 +60,7 @@ object Pos {
             data class PaymentNotFound(val message: String) : PaymentError
             data class PaymentExpired(val message: String) : PaymentError
             data class InvalidPaymentRequest(val message: String) : PaymentError
-            data object SanctionedUser : PaymentError
+            data object DeclinedUser : PaymentError
             data class Undefined(val message: String) : PaymentError
         }
     }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
@@ -1,6 +1,5 @@
 package com.walletconnect.pos.api
 
-import android.util.Log
 import com.squareup.moshi.Moshi
 import com.walletconnect.pos.BuildConfig
 import com.walletconnect.pos.Pos
@@ -16,8 +15,6 @@ import java.net.URI
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
-
-private const val TAG = "PosApiClient"
 
 internal class ApiClient(
     private val apiKey: String,
@@ -158,7 +155,6 @@ internal class ApiClient(
                         consecutiveTransientErrors = 0
 
                         if (data.status != lastEmittedStatus) {
-                            Log.d(TAG, "Status transition paymentId=$paymentId status=${data.status} isFinal=${data.isFinal} info=${data.info} failureCode=${data.failureCode}")
                             lastEmittedStatus = data.status
                             val event = mapStatusToPaymentEvent(data.status, paymentId, data.info, data.failureCode)
                             trackPaymentStatusEvent(paymentId, context, data.status, event)
@@ -179,7 +175,6 @@ internal class ApiClient(
                         } else {
                             activePollingState = null
                             val paymentError = mapErrorCodeToPaymentError(result.code, result.message)
-                            Log.w(TAG, "Polling terminal error paymentId=$paymentId code=${result.code} message=${result.message} mapped=${paymentError::class.simpleName}")
                             eventTracker.trackPaymentFailed(paymentId, context, paymentError)
                             onEvent(paymentError)
                             break
@@ -254,8 +249,7 @@ internal class ApiClient(
 
     private fun <T> parseErrorResponse(response: Response<T>): ApiErrorDetails {
         val errorBody = response.errorBody()?.string()
-        Log.w(TAG, "API error http=${response.code()} url=${response.raw().request.url} body=$errorBody")
-        val details = if (errorBody != null) {
+        return if (errorBody != null) {
             try {
                 errorAdapter.fromJson(errorBody)?.error ?: ApiErrorDetails(
                     code = "HTTP_${response.code()}",
@@ -274,8 +268,6 @@ internal class ApiClient(
                 message = response.message()
             )
         }
-        Log.w(TAG, "API error parsed: code=${details.code} message=${details.message}")
-        return details
     }
 
     private fun isSdkError(code: String): Boolean {

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
@@ -158,9 +158,9 @@ internal class ApiClient(
                         consecutiveTransientErrors = 0
 
                         if (data.status != lastEmittedStatus) {
-                            Log.d(TAG, "Status transition paymentId=$paymentId status=${data.status} isFinal=${data.isFinal} info=${data.info}")
+                            Log.d(TAG, "Status transition paymentId=$paymentId status=${data.status} isFinal=${data.isFinal} info=${data.info} failureCode=${data.failureCode}")
                             lastEmittedStatus = data.status
-                            val event = mapStatusToPaymentEvent(data.status, paymentId, data.info)
+                            val event = mapStatusToPaymentEvent(data.status, paymentId, data.info, data.failureCode)
                             trackPaymentStatusEvent(paymentId, context, data.status, event)
                             onEvent(event)
                         }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
@@ -1,5 +1,6 @@
 package com.walletconnect.pos.api
 
+import android.util.Log
 import com.squareup.moshi.Moshi
 import com.walletconnect.pos.BuildConfig
 import com.walletconnect.pos.Pos
@@ -15,6 +16,8 @@ import java.net.URI
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
+
+private const val TAG = "PosApiClient"
 
 internal class ApiClient(
     private val apiKey: String,
@@ -155,6 +158,7 @@ internal class ApiClient(
                         consecutiveTransientErrors = 0
 
                         if (data.status != lastEmittedStatus) {
+                            Log.d(TAG, "Status transition paymentId=$paymentId status=${data.status} isFinal=${data.isFinal} info=${data.info}")
                             lastEmittedStatus = data.status
                             val event = mapStatusToPaymentEvent(data.status, paymentId, data.info)
                             trackPaymentStatusEvent(paymentId, context, data.status, event)
@@ -175,6 +179,7 @@ internal class ApiClient(
                         } else {
                             activePollingState = null
                             val paymentError = mapErrorCodeToPaymentError(result.code, result.message)
+                            Log.w(TAG, "Polling terminal error paymentId=$paymentId code=${result.code} message=${result.message} mapped=${paymentError::class.simpleName}")
                             eventTracker.trackPaymentFailed(paymentId, context, paymentError)
                             onEvent(paymentError)
                             break
@@ -249,7 +254,8 @@ internal class ApiClient(
 
     private fun <T> parseErrorResponse(response: Response<T>): ApiErrorDetails {
         val errorBody = response.errorBody()?.string()
-        return if (errorBody != null) {
+        Log.w(TAG, "API error http=${response.code()} url=${response.raw().request.url} body=$errorBody")
+        val details = if (errorBody != null) {
             try {
                 errorAdapter.fromJson(errorBody)?.error ?: ApiErrorDetails(
                     code = "HTTP_${response.code()}",
@@ -268,6 +274,8 @@ internal class ApiClient(
                 message = response.message()
             )
         }
+        Log.w(TAG, "API error parsed: code=${details.code} message=${details.message}")
+        return details
     }
 
     private fun isSdkError(code: String): Boolean {

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
@@ -83,10 +83,14 @@ internal object PaymentStatus {
 }
 
 internal object ErrorCodes {
-    const val PAYMENT_NOT_FOUND = "PAYMENT_NOT_FOUND"
-    const val PAYMENT_EXPIRED = "PAYMENT_EXPIRED"
-    const val INVALID_REQUEST = "INVALID_REQUEST"
-    const val COMPLIANCE_FAILED = "COMPLIANCE_FAILED"
+    // API-origin codes — values match the server's ErrorCode enum (lowercase snake_case).
+    const val PAYMENT_NOT_FOUND = "payment_not_found"
+    const val PAYMENT_EXPIRED = "payment_expired"
+    const val INVALID_PARAMS = "invalid_params"
+    const val PARAMS_VALIDATION = "params_validation"
+    const val SANCTIONED_USER = "sanctioned_user"
+
+    // Internal sentinels — generated client-side, never received from the API.
     const val NETWORK_ERROR = "NETWORK_ERROR"
     const val PARSE_ERROR = "PARSE_ERROR"
 }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
@@ -30,7 +30,8 @@ internal data class GetPaymentStatusResponse(
     @param:Json(name = "status") val status: String,
     @param:Json(name = "pollInMs") val pollInMs: Long?,
     @param:Json(name = "isFinal") val isFinal: Boolean,
-    @param:Json(name = "info") val info: PaymentInfoDto?
+    @param:Json(name = "info") val info: PaymentInfoDto?,
+    @param:Json(name = "failureCode") val failureCode: String? = null
 )
 
 @JsonClass(generateAdapter = true)
@@ -93,6 +94,11 @@ internal object ErrorCodes {
     // Internal sentinels — generated client-side, never received from the API.
     const val NETWORK_ERROR = "NETWORK_ERROR"
     const val PARSE_ERROR = "PARSE_ERROR"
+}
+
+internal object FailureCodes {
+    // Wire values of GetPaymentStatusResponse.failureCode when status == "failed".
+    const val DECLINED_USER = "declined_user"
 }
 
 // Transaction History Models

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiModels.kt
@@ -89,7 +89,6 @@ internal object ErrorCodes {
     const val PAYMENT_EXPIRED = "payment_expired"
     const val INVALID_PARAMS = "invalid_params"
     const val PARAMS_VALIDATION = "params_validation"
-    const val SANCTIONED_USER = "sanctioned_user"
 
     // Internal sentinels — generated client-side, never received from the API.
     const val NETWORK_ERROR = "NETWORK_ERROR"

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
@@ -104,7 +104,7 @@ internal object ErrorCode {
     const val PAYMENT_EXPIRED = "PAYMENT_EXPIRED"
     const val INVALID_PAYMENT_REQUEST = "INVALID_PAYMENT_REQUEST"
     const val PAYMENT_CANCELLED = "PAYMENT_CANCELLED"
-    const val SANCTIONED_USER = "SANCTIONED_USER"
+    const val DECLINED_USER = "DECLINED_USER"
     const val UNDEFINED_ERROR = "UNDEFINED_ERROR"
 }
 
@@ -140,9 +140,9 @@ internal fun Pos.PaymentEvent.PaymentError.toErrorFields(): ErrorFields {
             code = ErrorCode.INVALID_PAYMENT_REQUEST,
             message = message
         )
-        is Pos.PaymentEvent.PaymentError.SanctionedUser -> ErrorFields(
+        is Pos.PaymentEvent.PaymentError.DeclinedUser -> ErrorFields(
             category = ErrorCategory.API,
-            code = ErrorCode.SANCTIONED_USER,
+            code = ErrorCode.DECLINED_USER,
             message = ""
         )
         is Pos.PaymentEvent.PaymentError.Undefined -> ErrorFields(

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/EventModels.kt
@@ -104,6 +104,7 @@ internal object ErrorCode {
     const val PAYMENT_EXPIRED = "PAYMENT_EXPIRED"
     const val INVALID_PAYMENT_REQUEST = "INVALID_PAYMENT_REQUEST"
     const val PAYMENT_CANCELLED = "PAYMENT_CANCELLED"
+    const val SANCTIONED_USER = "SANCTIONED_USER"
     const val UNDEFINED_ERROR = "UNDEFINED_ERROR"
 }
 
@@ -138,6 +139,11 @@ internal fun Pos.PaymentEvent.PaymentError.toErrorFields(): ErrorFields {
             category = ErrorCategory.VALIDATION,
             code = ErrorCode.INVALID_PAYMENT_REQUEST,
             message = message
+        )
+        is Pos.PaymentEvent.PaymentError.SanctionedUser -> ErrorFields(
+            category = ErrorCategory.API,
+            code = ErrorCode.SANCTIONED_USER,
+            message = ""
         )
         is Pos.PaymentEvent.PaymentError.Undefined -> ErrorFields(
             category = ErrorCategory.UNKNOWN,

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
@@ -25,14 +25,18 @@ internal fun mapCreatePaymentError(code: String, message: String): Pos.PaymentEv
 internal fun mapStatusToPaymentEvent(
     status: String,
     paymentId: String,
-    info: PaymentInfoDto? = null
+    info: PaymentInfoDto? = null,
+    failureCode: String? = null
 ): Pos.PaymentEvent {
     return when (status) {
         PaymentStatus.REQUIRES_ACTION -> Pos.PaymentEvent.PaymentRequested
         PaymentStatus.PROCESSING -> Pos.PaymentEvent.PaymentProcessing
         PaymentStatus.SUCCEEDED -> Pos.PaymentEvent.PaymentSuccess(paymentId, info?.toPaymentInfo())
         PaymentStatus.EXPIRED -> Pos.PaymentEvent.PaymentError.PaymentExpired("Payment has expired")
-        PaymentStatus.FAILED -> Pos.PaymentEvent.PaymentError.PaymentFailed("Payment failed") //TODO: add error message?
+        PaymentStatus.FAILED -> when (failureCode) {
+            FailureCodes.DECLINED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
+            else -> Pos.PaymentEvent.PaymentError.PaymentFailed("Payment failed")
+        }
         PaymentStatus.CANCELLED -> Pos.PaymentEvent.PaymentError.PaymentCancelled("Payment cancelled")
         else -> Pos.PaymentEvent.PaymentError.Undefined("Unknown payment status: $status")
     }

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
@@ -4,7 +4,6 @@ import com.walletconnect.pos.Pos
 
 internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
-        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.DeclinedUser
         ErrorCodes.PAYMENT_NOT_FOUND -> Pos.PaymentEvent.PaymentError.PaymentNotFound(message)
         ErrorCodes.PAYMENT_EXPIRED -> Pos.PaymentEvent.PaymentError.PaymentExpired(message)
         ErrorCodes.INVALID_PARAMS,
@@ -15,7 +14,6 @@ internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.Paym
 
 internal fun mapCreatePaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
-        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.DeclinedUser
         ErrorCodes.INVALID_PARAMS,
         ErrorCodes.PARAMS_VALIDATION -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
         else -> Pos.PaymentEvent.PaymentError.CreatePaymentFailed(message)

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
@@ -4,7 +4,7 @@ import com.walletconnect.pos.Pos
 
 internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
-        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
+        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.DeclinedUser
         ErrorCodes.PAYMENT_NOT_FOUND -> Pos.PaymentEvent.PaymentError.PaymentNotFound(message)
         ErrorCodes.PAYMENT_EXPIRED -> Pos.PaymentEvent.PaymentError.PaymentExpired(message)
         ErrorCodes.INVALID_PARAMS,
@@ -15,7 +15,7 @@ internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.Paym
 
 internal fun mapCreatePaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
-        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
+        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.DeclinedUser
         ErrorCodes.INVALID_PARAMS,
         ErrorCodes.PARAMS_VALIDATION -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
         else -> Pos.PaymentEvent.PaymentError.CreatePaymentFailed(message)
@@ -34,7 +34,7 @@ internal fun mapStatusToPaymentEvent(
         PaymentStatus.SUCCEEDED -> Pos.PaymentEvent.PaymentSuccess(paymentId, info?.toPaymentInfo())
         PaymentStatus.EXPIRED -> Pos.PaymentEvent.PaymentError.PaymentExpired("Payment has expired")
         PaymentStatus.FAILED -> when (failureCode) {
-            FailureCodes.DECLINED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
+            FailureCodes.DECLINED_USER -> Pos.PaymentEvent.PaymentError.DeclinedUser
             else -> Pos.PaymentEvent.PaymentError.PaymentFailed("Payment failed")
         }
         PaymentStatus.CANCELLED -> Pos.PaymentEvent.PaymentError.PaymentCancelled("Payment cancelled")

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
@@ -4,16 +4,20 @@ import com.walletconnect.pos.Pos
 
 internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
+        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
         ErrorCodes.PAYMENT_NOT_FOUND -> Pos.PaymentEvent.PaymentError.PaymentNotFound(message)
         ErrorCodes.PAYMENT_EXPIRED -> Pos.PaymentEvent.PaymentError.PaymentExpired(message)
-        ErrorCodes.INVALID_REQUEST -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
+        ErrorCodes.INVALID_PARAMS,
+        ErrorCodes.PARAMS_VALIDATION -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
         else -> Pos.PaymentEvent.PaymentError.Undefined(message)
     }
 }
 
 internal fun mapCreatePaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {
-        ErrorCodes.INVALID_REQUEST -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
+        ErrorCodes.SANCTIONED_USER -> Pos.PaymentEvent.PaymentError.SanctionedUser
+        ErrorCodes.INVALID_PARAMS,
+        ErrorCodes.PARAMS_VALIDATION -> Pos.PaymentEvent.PaymentError.InvalidPaymentRequest(message)
         else -> Pos.PaymentEvent.PaymentError.CreatePaymentFailed(message)
     }
 }

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
@@ -220,7 +220,6 @@ class ApiClientTest {
         assertEquals("payment_expired", ErrorCodes.PAYMENT_EXPIRED)
         assertEquals("invalid_params", ErrorCodes.INVALID_PARAMS)
         assertEquals("params_validation", ErrorCodes.PARAMS_VALIDATION)
-        assertEquals("sanctioned_user", ErrorCodes.SANCTIONED_USER)
         assertEquals("NETWORK_ERROR", ErrorCodes.NETWORK_ERROR)
         assertEquals("PARSE_ERROR", ErrorCodes.PARSE_ERROR)
     }

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
@@ -124,7 +124,7 @@ class ApiClientTest {
     @Test
     fun `getPaymentStatus - returns error when payment not found`() = runTest {
         val mockApi = mockk<PayApi>()
-        val errorBody = """{"status":"error","error":{"code":"PAYMENT_NOT_FOUND","message":"Payment not found"}}"""
+        val errorBody = """{"status":"error","error":{"code":"payment_not_found","message":"Payment not found"}}"""
             .toResponseBody("application/json".toMediaType())
 
         coEvery { mockApi.getPaymentStatus("invalid_id") } returns Response.error(404, errorBody)
@@ -216,10 +216,11 @@ class ApiClientTest {
 
     @Test
     fun `ErrorCodes constants have correct values`() {
-        assertEquals("PAYMENT_NOT_FOUND", ErrorCodes.PAYMENT_NOT_FOUND)
-        assertEquals("PAYMENT_EXPIRED", ErrorCodes.PAYMENT_EXPIRED)
-        assertEquals("INVALID_REQUEST", ErrorCodes.INVALID_REQUEST)
-        assertEquals("COMPLIANCE_FAILED", ErrorCodes.COMPLIANCE_FAILED)
+        assertEquals("payment_not_found", ErrorCodes.PAYMENT_NOT_FOUND)
+        assertEquals("payment_expired", ErrorCodes.PAYMENT_EXPIRED)
+        assertEquals("invalid_params", ErrorCodes.INVALID_PARAMS)
+        assertEquals("params_validation", ErrorCodes.PARAMS_VALIDATION)
+        assertEquals("sanctioned_user", ErrorCodes.SANCTIONED_USER)
         assertEquals("NETWORK_ERROR", ErrorCodes.NETWORK_ERROR)
         assertEquals("PARSE_ERROR", ErrorCodes.PARSE_ERROR)
     }

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
@@ -119,12 +119,6 @@ class MappingTest {
     }
 
     @Test
-    fun `mapErrorCodeToPaymentError - sanctioned_user returns DeclinedUser singleton`() {
-        val result = mapErrorCodeToPaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
-        assertSame(Pos.PaymentEvent.PaymentError.DeclinedUser, result)
-    }
-
-    @Test
     fun `mapErrorCodeToPaymentError - unknown code returns Undefined`() {
         val result = mapErrorCodeToPaymentError("UNKNOWN_CODE", "Unknown error")
         assertTrue(result is Pos.PaymentEvent.PaymentError.Undefined)
@@ -157,12 +151,6 @@ class MappingTest {
         val result = mapCreatePaymentError(ErrorCodes.PARAMS_VALIDATION, "Validation failed")
         assertTrue(result is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest)
         assertEquals("Validation failed", (result as Pos.PaymentEvent.PaymentError.InvalidPaymentRequest).message)
-    }
-
-    @Test
-    fun `mapCreatePaymentError - sanctioned_user returns DeclinedUser singleton`() {
-        val result = mapCreatePaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
-        assertSame(Pos.PaymentEvent.PaymentError.DeclinedUser, result)
     }
 
     @Test
@@ -255,7 +243,6 @@ class MappingTest {
         assertEquals("payment_expired", ErrorCodes.PAYMENT_EXPIRED)
         assertEquals("invalid_params", ErrorCodes.INVALID_PARAMS)
         assertEquals("params_validation", ErrorCodes.PARAMS_VALIDATION)
-        assertEquals("sanctioned_user", ErrorCodes.SANCTIONED_USER)
     }
 
     @Test

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
@@ -6,6 +6,7 @@ import com.walletconnect.pos.api.mapCreatePaymentError
 import com.walletconnect.pos.api.mapErrorCodeToPaymentError
 import com.walletconnect.pos.api.mapStatusToPaymentEvent
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -83,10 +84,23 @@ class MappingTest {
     }
 
     @Test
-    fun `mapErrorCodeToPaymentError - INVALID_REQUEST returns InvalidPaymentRequest`() {
-        val result = mapErrorCodeToPaymentError(ErrorCodes.INVALID_REQUEST, "Invalid")
+    fun `mapErrorCodeToPaymentError - INVALID_PARAMS returns InvalidPaymentRequest`() {
+        val result = mapErrorCodeToPaymentError(ErrorCodes.INVALID_PARAMS, "Invalid")
         assertTrue(result is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest)
         assertEquals("Invalid", (result as Pos.PaymentEvent.PaymentError.InvalidPaymentRequest).message)
+    }
+
+    @Test
+    fun `mapErrorCodeToPaymentError - PARAMS_VALIDATION returns InvalidPaymentRequest`() {
+        val result = mapErrorCodeToPaymentError(ErrorCodes.PARAMS_VALIDATION, "Validation failed")
+        assertTrue(result is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest)
+        assertEquals("Validation failed", (result as Pos.PaymentEvent.PaymentError.InvalidPaymentRequest).message)
+    }
+
+    @Test
+    fun `mapErrorCodeToPaymentError - sanctioned_user returns SanctionedUser singleton`() {
+        val result = mapErrorCodeToPaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
+        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
     }
 
     @Test
@@ -111,10 +125,23 @@ class MappingTest {
     }
 
     @Test
-    fun `mapCreatePaymentError - INVALID_REQUEST returns InvalidPaymentRequest`() {
-        val result = mapCreatePaymentError(ErrorCodes.INVALID_REQUEST, "Invalid amount")
+    fun `mapCreatePaymentError - INVALID_PARAMS returns InvalidPaymentRequest`() {
+        val result = mapCreatePaymentError(ErrorCodes.INVALID_PARAMS, "Invalid amount")
         assertTrue(result is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest)
         assertEquals("Invalid amount", (result as Pos.PaymentEvent.PaymentError.InvalidPaymentRequest).message)
+    }
+
+    @Test
+    fun `mapCreatePaymentError - PARAMS_VALIDATION returns InvalidPaymentRequest`() {
+        val result = mapCreatePaymentError(ErrorCodes.PARAMS_VALIDATION, "Validation failed")
+        assertTrue(result is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest)
+        assertEquals("Validation failed", (result as Pos.PaymentEvent.PaymentError.InvalidPaymentRequest).message)
+    }
+
+    @Test
+    fun `mapCreatePaymentError - sanctioned_user returns SanctionedUser singleton`() {
+        val result = mapCreatePaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
+        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
     }
 
     @Test
@@ -203,9 +230,10 @@ class MappingTest {
 
     @Test
     fun `ErrorCodes constants have correct values`() {
-        assertEquals("PAYMENT_NOT_FOUND", ErrorCodes.PAYMENT_NOT_FOUND)
-        assertEquals("PAYMENT_EXPIRED", ErrorCodes.PAYMENT_EXPIRED)
-        assertEquals("INVALID_REQUEST", ErrorCodes.INVALID_REQUEST)
-        assertEquals("COMPLIANCE_FAILED", ErrorCodes.COMPLIANCE_FAILED)
+        assertEquals("payment_not_found", ErrorCodes.PAYMENT_NOT_FOUND)
+        assertEquals("payment_expired", ErrorCodes.PAYMENT_EXPIRED)
+        assertEquals("invalid_params", ErrorCodes.INVALID_PARAMS)
+        assertEquals("params_validation", ErrorCodes.PARAMS_VALIDATION)
+        assertEquals("sanctioned_user", ErrorCodes.SANCTIONED_USER)
     }
 }

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
@@ -52,13 +52,13 @@ class MappingTest {
     }
 
     @Test
-    fun `mapStatusToPaymentEvent - failed with declined_user failureCode returns SanctionedUser`() {
+    fun `mapStatusToPaymentEvent - failed with declined_user failureCode returns DeclinedUser`() {
         val result = mapStatusToPaymentEvent(
             status = PaymentStatus.FAILED,
             paymentId = "pay_123",
             failureCode = FailureCodes.DECLINED_USER
         )
-        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
+        assertSame(Pos.PaymentEvent.PaymentError.DeclinedUser, result)
     }
 
     @Test
@@ -119,9 +119,9 @@ class MappingTest {
     }
 
     @Test
-    fun `mapErrorCodeToPaymentError - sanctioned_user returns SanctionedUser singleton`() {
+    fun `mapErrorCodeToPaymentError - sanctioned_user returns DeclinedUser singleton`() {
         val result = mapErrorCodeToPaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
-        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
+        assertSame(Pos.PaymentEvent.PaymentError.DeclinedUser, result)
     }
 
     @Test
@@ -160,9 +160,9 @@ class MappingTest {
     }
 
     @Test
-    fun `mapCreatePaymentError - sanctioned_user returns SanctionedUser singleton`() {
+    fun `mapCreatePaymentError - sanctioned_user returns DeclinedUser singleton`() {
         val result = mapCreatePaymentError(ErrorCodes.SANCTIONED_USER, "any server message")
-        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
+        assertSame(Pos.PaymentEvent.PaymentError.DeclinedUser, result)
     }
 
     @Test

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/MappingTest.kt
@@ -1,6 +1,7 @@
 package com.walletconnect.pos
 
 import com.walletconnect.pos.api.ErrorCodes
+import com.walletconnect.pos.api.FailureCodes
 import com.walletconnect.pos.api.PaymentStatus
 import com.walletconnect.pos.api.mapCreatePaymentError
 import com.walletconnect.pos.api.mapErrorCodeToPaymentError
@@ -47,6 +48,26 @@ class MappingTest {
     @Test
     fun `mapStatusToPaymentEvent - failed returns PaymentError PaymentFailed`() {
         val result = mapStatusToPaymentEvent(PaymentStatus.FAILED, "pay_123")
+        assertTrue(result is Pos.PaymentEvent.PaymentError.PaymentFailed)
+    }
+
+    @Test
+    fun `mapStatusToPaymentEvent - failed with declined_user failureCode returns SanctionedUser`() {
+        val result = mapStatusToPaymentEvent(
+            status = PaymentStatus.FAILED,
+            paymentId = "pay_123",
+            failureCode = FailureCodes.DECLINED_USER
+        )
+        assertSame(Pos.PaymentEvent.PaymentError.SanctionedUser, result)
+    }
+
+    @Test
+    fun `mapStatusToPaymentEvent - failed with unknown failureCode falls back to PaymentFailed`() {
+        val result = mapStatusToPaymentEvent(
+            status = PaymentStatus.FAILED,
+            paymentId = "pay_123",
+            failureCode = "some_future_code"
+        )
         assertTrue(result is Pos.PaymentEvent.PaymentError.PaymentFailed)
     }
 
@@ -235,5 +256,10 @@ class MappingTest {
         assertEquals("invalid_params", ErrorCodes.INVALID_PARAMS)
         assertEquals("params_validation", ErrorCodes.PARAMS_VALIDATION)
         assertEquals("sanctioned_user", ErrorCodes.SANCTIONED_USER)
+    }
+
+    @Test
+    fun `FailureCodes constants have correct values`() {
+        assertEquals("declined_user", FailureCodes.DECLINED_USER)
     }
 }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -328,7 +328,7 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
                     is Pos.PaymentEvent.PaymentError.PaymentCancelled -> "cancelled"
                     is Pos.PaymentEvent.PaymentError.PaymentNotFound -> "not_found"
                     is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest -> "invalid_request"
-                    is Pos.PaymentEvent.PaymentError.SanctionedUser -> "sanctioned_user"
+                    is Pos.PaymentEvent.PaymentError.DeclinedUser -> "declined_user"
                     is Pos.PaymentEvent.PaymentError.Undefined -> "unknown"
                 }
                 PosLogStore.error(

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -328,6 +328,7 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
                     is Pos.PaymentEvent.PaymentError.PaymentCancelled -> "cancelled"
                     is Pos.PaymentEvent.PaymentError.PaymentNotFound -> "not_found"
                     is Pos.PaymentEvent.PaymentError.InvalidPaymentRequest -> "invalid_request"
+                    is Pos.PaymentEvent.PaymentError.SanctionedUser -> "sanctioned_user"
                     is Pos.PaymentEvent.PaymentError.Undefined -> "unknown"
                 }
                 PosLogStore.error(

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/ErrorScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/ErrorScreen.kt
@@ -128,6 +128,7 @@ private fun getErrorMessages(errorCode: String): Pair<String, String> {
         "create_failed" -> "Payment can't be completed" to "We're unable to complete this payment at this time. Please generate a new payment and try again."
         "not_found" -> "Payment not found" to "The payment could not be found. Please try creating a new one."
         "invalid_request" -> "Invalid request" to "The payment request was invalid. Please try again with a valid amount."
+        "declined_user" -> "Payment declined" to "This account can't be used for this payment. Please try a different account."
         ErrorCodes.INIT_FAILED -> "Initialization failed" to "POS SDK could not be initialized. Check that MERCHANT_API_KEY and MERCHANT_ID are configured correctly."
         else -> "Payment can't be completed" to "We're unable to complete this payment at this time. Please generate a new payment and try again."
     }


### PR DESCRIPTION
## Summary

- Adds a dedicated message-less `Pos.PaymentEvent.PaymentError.SanctionedUser` variant so integrators can pattern-match on sanctions-list responses without receiving any server-provided string.
- Aligns POS `ErrorCodes` values with the Pay API spec (lowercase snake_case); API-origin codes previously used UPPERCASE which never matched real responses.
- Splits the unused `INVALID_REQUEST` into the two real spec codes (`invalid_params`, `params_validation`), both mapping to the existing `InvalidPaymentRequest` variant.
- Removes the unused `COMPLIANCE_FAILED` constant (not in spec, never branched on, no sample usage).

## Error flow

```mermaid
flowchart LR
    API["Pay API<br/>sanctioned_user"] --> Parse[parseErrorResponse]
    Parse --> Map{mapErrorCodeToPaymentError<br/>mapCreatePaymentError}
    Map -->|sanctioned_user| New["PaymentError.SanctionedUser<br/>(no message)"]
    Map -->|invalid_params<br/>params_validation| Invalid[PaymentError.InvalidPaymentRequest]
    Map -->|payment_not_found| NotFound[PaymentError.PaymentNotFound]
    Map -->|payment_expired| Expired[PaymentError.PaymentExpired]
    Map -->|else| Undef[PaymentError.Undefined]
    New --> Delegate[POSDelegate.onEvent]
```

## Test plan

- [x] `./gradlew :product:pos:compileDebugKotlin :sample:pos:compileDebugKotlin` — passes (exhaustive `when` over sealed hierarchy enforces the new branch).
- [x] `./gradlew :product:pos:testDebugUnitTest` — passes; added 4 new tests (`SanctionedUser` and `PARAMS_VALIDATION` for both mappers).
- [ ] Manual end-to-end: trigger a `sanctioned_user` response against staging and confirm `POSDelegate.onEvent` receives `Pos.PaymentEvent.PaymentError.SanctionedUser` (singleton reference equality) with no server message exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)