### PR TITLE
feat(pos): print receipts via generic Bluetooth ESC/POS

### DIFF
--- a/sample/pos/build.gradle.kts
+++ b/sample/pos/build.gradle.kts
@@ -117,5 +117,10 @@ dependencies {
 
     // Logging
     implementation("com.jakewharton.timber:timber:5.0.1")
+
+    // Receipt printing — generic ESC/POS over Bluetooth (works with any paired thermal printer,
+    // including iMin's built-in head once paired internally).
+    implementation("com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.3.0")
+
     testImplementation(libs.jUnit)
 }

--- a/sample/pos/src/main/AndroidManifest.xml
+++ b/sample/pos/src/main/AndroidManifest.xml
@@ -4,12 +4,29 @@
 
     <uses-permission android:name="android.permission.NFC" />
 
+    <!-- Bluetooth permissions for the generic ESC/POS receipt printer driver. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+
     <uses-feature
         android:name="android.hardware.nfc"
         android:required="false" />
 
     <uses-feature
         android:name="android.hardware.nfc.hce"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.bluetooth"
         android:required="false" />
 
     <application

--- a/sample/pos/src/main/AndroidManifest.xml
+++ b/sample/pos/src/main/AndroidManifest.xml
@@ -4,18 +4,19 @@
 
     <uses-permission android:name="android.permission.NFC" />
 
-    <!-- Bluetooth permissions for the generic ESC/POS receipt printer driver. -->
+    <!-- Bluetooth permissions for the generic ESC/POS receipt printer driver.
+         We only connect to already-paired devices, never derive location from scans. -->
     <uses-permission
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
     <uses-permission
         android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.ACCESS_FINE_LOCATION"
-        android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
 
     <uses-feature
         android:name="android.hardware.nfc"

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSActivity.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSActivity.kt
@@ -1,8 +1,12 @@
 package com.walletconnect.sample.pos
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -10,6 +14,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.compositeOver
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.walletconnect.sample.pos.ui.theme.LocalWCColors
 import com.walletconnect.sample.pos.ui.theme.WCSampleAppTheme
@@ -22,11 +27,16 @@ import com.walletconnect.sample.pos.ui.theme.WCTheme
 class POSActivity : AppCompatActivity() {
     private val viewModel: POSViewModel by viewModels()
 
+    private val bluetoothPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { /* result ignored — driver surfaces a clear error if permission is still missing */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         NfcManager.init(this)
         enableEdgeToEdge()
+        requestBluetoothPermissionsIfNeeded()
 
         setContent {
             val themeMode by viewModel.selectedThemeMode.collectAsState()
@@ -85,5 +95,12 @@ class POSActivity : AppCompatActivity() {
         if (POSApplication.initError == null) {
             try { PosClient.pause() } catch (_: IllegalStateException) { /* not yet initialized */ }
         }
+    }
+
+    private fun requestBluetoothPermissionsIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        val needed = listOf(Manifest.permission.BLUETOOTH_CONNECT, Manifest.permission.BLUETOOTH_SCAN)
+            .filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
+        if (needed.isNotEmpty()) bluetoothPermissionLauncher.launch(needed.toTypedArray())
     }
 }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSSampleHost.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSSampleHost.kt
@@ -1,6 +1,7 @@
 package com.walletconnect.sample.pos
 
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
@@ -9,6 +10,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.navigation.NavHostController
@@ -59,7 +61,22 @@ fun POSSampleHost(
     navController: NavHostController = rememberNavController(),
 ) {
     val scaffoldState: ScaffoldState = rememberScaffoldState()
+    val context = LocalContext.current
     val initError = POSApplication.initError
+
+    LaunchedEffect(Unit) {
+        viewModel.posEventsFlow.collect { event ->
+            when (event) {
+                is PosEvent.PrintSuccess -> Toast.makeText(
+                    context,
+                    if (event.isTest) "Test sent to printer" else "Receipt sent to printer",
+                    Toast.LENGTH_SHORT
+                ).show()
+                is PosEvent.PrintError -> Toast.makeText(context, event.message, Toast.LENGTH_LONG).show()
+                else -> Unit
+            }
+        }
+    }
     val startDestination = if (initError != null) {
         Screen.ErrorScreen.routeWith(ErrorCodes.INIT_FAILED)
     } else {
@@ -177,6 +194,9 @@ fun POSSampleHost(
                             launchSingleTop = true
                         }
                         navController.navigate(Screen.AmountScreen.route)
+                    },
+                    onPrintReceipt = {
+                        viewModel.printReceipt(amount.orEmpty(), viewModel.lastPaymentInfo)
                     },
                 )
             }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -143,30 +143,26 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
 
     fun printReceipt(displayAmount: String, info: Pos.PaymentInfo?) {
         viewModelScope.launch(Dispatchers.IO) {
-            executePrint(ReceiptData.from(displayAmount, info), isTest = false)
+            executePrint(ReceiptData.from(displayAmount, info), isTest = false, source = "printReceipt")
         }
     }
 
     fun printTestReceipt() {
         viewModelScope.launch(Dispatchers.IO) {
-            executePrint(ReceiptData.sample(), isTest = true)
+            executePrint(ReceiptData.sample(), isTest = true, source = "printTestReceipt")
         }
     }
 
-    private suspend fun executePrint(receipt: ReceiptData, isTest: Boolean) {
-        PosLogStore.info(
-            "Print receipt requested",
-            source = "printReceipt",
-            data = "isTest: $isTest"
-        )
+    private suspend fun executePrint(receipt: ReceiptData, isTest: Boolean, source: String) {
+        PosLogStore.info("Print receipt requested", source = source)
         printerManager.print(receipt).fold(
             onSuccess = {
-                PosLogStore.info("Receipt printed", source = "printReceipt")
+                PosLogStore.info("Receipt printed", source = source)
                 _posEventsFlow.emit(PosEvent.PrintSuccess(isTest))
             },
             onFailure = { error ->
                 val msg = error.message ?: "Failed to print receipt"
-                PosLogStore.error("Print failed: $msg", source = "printReceipt")
+                PosLogStore.error("Print failed: $msg", source = source)
                 _posEventsFlow.emit(PosEvent.PrintError(msg))
             }
         )

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -18,6 +18,8 @@ import com.walletconnect.sample.pos.model.Currency
 import com.walletconnect.sample.pos.model.PosVariant
 import com.walletconnect.sample.pos.model.ThemeMode
 import com.walletconnect.sample.pos.model.formatAmountWithSymbol
+import com.walletconnect.sample.pos.printer.PrinterManager
+import com.walletconnect.sample.pos.printer.ReceiptData
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -45,6 +47,8 @@ sealed interface PosEvent {
     data object PaymentProcessing : PosEvent
     data class PaymentSuccess(val paymentId: String, val info: Pos.PaymentInfo?) : PosEvent
     data class PaymentError(val error: String) : PosEvent
+    data class PrintSuccess(val isTest: Boolean) : PosEvent
+    data class PrintError(val message: String) : PosEvent
 }
 
 sealed interface TransactionHistoryUiState {
@@ -133,6 +137,39 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
         _selectedVariant.value = variant
         prefs.edit().putString(KEY_VARIANT, variant.name).apply()
         variant.defaultTheme?.let { setThemeMode(it) }
+    }
+
+    private val printerManager = PrinterManager(application)
+
+    fun printReceipt(displayAmount: String, info: Pos.PaymentInfo?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            executePrint(ReceiptData.from(displayAmount, info), isTest = false)
+        }
+    }
+
+    fun printTestReceipt() {
+        viewModelScope.launch(Dispatchers.IO) {
+            executePrint(ReceiptData.sample(), isTest = true)
+        }
+    }
+
+    private suspend fun executePrint(receipt: ReceiptData, isTest: Boolean) {
+        PosLogStore.info(
+            "Print receipt requested",
+            source = "printReceipt",
+            data = "isTest: $isTest"
+        )
+        printerManager.print(receipt).fold(
+            onSuccess = {
+                PosLogStore.info("Receipt printed", source = "printReceipt")
+                _posEventsFlow.emit(PosEvent.PrintSuccess(isTest))
+            },
+            onFailure = { error ->
+                val msg = error.message ?: "Failed to print receipt"
+                PosLogStore.error("Print failed: $msg", source = "printReceipt")
+                _posEventsFlow.emit(PosEvent.PrintError(msg))
+            }
+        )
     }
 
     // Merchant credentials (persisted securely)

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/GenericBluetoothPrinter.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/GenericBluetoothPrinter.kt
@@ -17,7 +17,7 @@ internal class GenericBluetoothPrinter(private val context: Context) : Printer {
     override suspend fun isAvailable(): Boolean = withContext(Dispatchers.IO) {
         val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
         val adapter: BluetoothAdapter? = manager?.adapter
-        adapter?.isEnabled == true && firstPairedConnection() != null
+        adapter?.isEnabled == true && runCatching { firstPairedConnection() }.getOrNull() != null
     }
 
     override suspend fun print(receipt: ReceiptData, logo: Bitmap): Result<Unit> = withContext(Dispatchers.IO) {
@@ -38,7 +38,7 @@ internal class GenericBluetoothPrinter(private val context: Context) : Printer {
     private fun firstPairedConnection(): BluetoothConnection? = try {
         BluetoothPrintersConnections.selectFirstPaired()
     } catch (e: SecurityException) {
-        null
+        throw SecurityException("Bluetooth permission denied. Grant Bluetooth permissions in system settings.", e)
     }
 
     companion object {

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/GenericBluetoothPrinter.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/GenericBluetoothPrinter.kt
@@ -1,0 +1,49 @@
+package com.walletconnect.sample.pos.printer
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import com.dantsu.escposprinter.EscPosPrinter
+import com.dantsu.escposprinter.connection.bluetooth.BluetoothConnection
+import com.dantsu.escposprinter.connection.bluetooth.BluetoothPrintersConnections
+import com.dantsu.escposprinter.textparser.PrinterTextParserImg
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal class GenericBluetoothPrinter(private val context: Context) : Printer {
+
+    override suspend fun isAvailable(): Boolean = withContext(Dispatchers.IO) {
+        val manager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter: BluetoothAdapter? = manager?.adapter
+        adapter?.isEnabled == true && firstPairedConnection() != null
+    }
+
+    override suspend fun print(receipt: ReceiptData, logo: Bitmap): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val connection = firstPairedConnection()
+                ?: error("No paired Bluetooth printer found. Pair a thermal printer in Android settings first.")
+            val printer = EscPosPrinter(connection, PRINTER_DPI, PRINTER_WIDTH_MM, PRINTER_CHARS_PER_LINE)
+            try {
+                val logoMarkup = "[C]<img>" + PrinterTextParserImg.bitmapToHexadecimalString(printer, BitmapDrawable(context.resources, logo)) + "</img>\n"
+                printer.printFormattedTextAndCut(logoMarkup + ReceiptFormatter.toGenericMarkup(receipt))
+            } finally {
+                printer.disconnectPrinter()
+            }
+            Unit
+        }
+    }
+
+    private fun firstPairedConnection(): BluetoothConnection? = try {
+        BluetoothPrintersConnections.selectFirstPaired()
+    } catch (e: SecurityException) {
+        null
+    }
+
+    companion object {
+        private const val PRINTER_DPI = 203
+        private const val PRINTER_WIDTH_MM = 48f
+        private const val PRINTER_CHARS_PER_LINE = 32
+    }
+}

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/Printer.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/Printer.kt
@@ -1,0 +1,8 @@
+package com.walletconnect.sample.pos.printer
+
+import android.graphics.Bitmap
+
+internal interface Printer {
+    suspend fun isAvailable(): Boolean
+    suspend fun print(receipt: ReceiptData, logo: Bitmap): Result<Unit>
+}

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
@@ -1,0 +1,57 @@
+package com.walletconnect.sample.pos.printer
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import androidx.appcompat.content.res.AppCompatResources
+import com.walletconnect.sample.pos.R
+
+internal class PrinterManager(private val context: Context) {
+
+    private val printer: Printer = GenericBluetoothPrinter(context)
+
+    suspend fun print(receipt: ReceiptData): Result<Unit> = printer.print(receipt, logoBitmap())
+
+    private fun logoBitmap(): Bitmap {
+        val drawable = AppCompatResources.getDrawable(context, R.drawable.ic_wcpay_logo)
+            ?: error("Receipt logo drawable missing: ic_wcpay_logo")
+        val srcWidth = drawable.intrinsicWidth.takeIf { it > 0 } ?: LOGO_TARGET_WIDTH
+        val srcHeight = drawable.intrinsicHeight.takeIf { it > 0 } ?: (LOGO_TARGET_WIDTH / 3)
+        val targetHeight = (LOGO_TARGET_WIDTH * srcHeight / srcWidth).coerceAtLeast(1)
+
+        // Render the vector at target printer resolution onto a white background — vectors stay crisp
+        // at any size, unlike upscaling a small raster which produces blurry edges after thresholding.
+        val bitmap = Bitmap.createBitmap(LOGO_TARGET_WIDTH, targetHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        drawable.setBounds(0, 0, LOGO_TARGET_WIDTH, targetHeight)
+        drawable.draw(canvas)
+
+        return thresholdToMonochrome(bitmap)
+    }
+
+    private fun thresholdToMonochrome(src: Bitmap): Bitmap {
+        val w = src.width
+        val h = src.height
+        val pixels = IntArray(w * h)
+        src.getPixels(pixels, 0, w, 0, 0, w, h)
+        for (i in pixels.indices) {
+            val p = pixels[i]
+            val r = (p shr 16) and 0xff
+            val g = (p shr 8) and 0xff
+            val b = p and 0xff
+            val luma = (r * 299 + g * 587 + b * 114) / 1000
+            pixels[i] = if (luma < LUMA_THRESHOLD) Color.BLACK else Color.WHITE
+        }
+        val out = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        out.setPixels(pixels, 0, w, 0, 0, w, h)
+        return out
+    }
+
+    companion object {
+        // Target a width that fits comfortably inside the 384-dot, 48mm @ 203 DPI thermal head
+        private const val LOGO_TARGET_WIDTH = 320
+        private const val LUMA_THRESHOLD = 160
+    }
+}

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptData.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptData.kt
@@ -1,9 +1,8 @@
 package com.walletconnect.sample.pos.printer
 
 import com.walletconnect.pos.Pos
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 internal data class ReceiptData(
     val txId: String,
@@ -15,7 +14,7 @@ internal data class ReceiptData(
     val footerOverride: String? = null
 ) {
     companion object {
-        private val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+        private val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
         fun from(displayFiat: String, info: Pos.PaymentInfo?): ReceiptData {
             val tokenAmount = info?.let { paymentInfo ->
@@ -32,7 +31,7 @@ internal data class ReceiptData(
             }
             return ReceiptData(
                 txId = info?.txHash ?: "",
-                date = DATE_FORMAT.format(Date()),
+                date = DATE_FORMAT.format(LocalDateTime.now()),
                 displayFiat = displayFiat,
                 tokenSymbol = info?.assetSymbol,
                 tokenAmountFormatted = tokenAmount,
@@ -42,7 +41,7 @@ internal data class ReceiptData(
 
         fun sample() = ReceiptData(
             txId = "0xTEST0000000000000000000000000000000000000000",
-            date = DATE_FORMAT.format(Date()),
+            date = DATE_FORMAT.format(LocalDateTime.now()),
             displayFiat = "$1.00 USD",
             tokenSymbol = "USDC",
             tokenAmountFormatted = "1.00",

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptData.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptData.kt
@@ -1,0 +1,53 @@
+package com.walletconnect.sample.pos.printer
+
+import com.walletconnect.pos.Pos
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal data class ReceiptData(
+    val txId: String,
+    val date: String,
+    val displayFiat: String,
+    val tokenSymbol: String?,
+    val tokenAmountFormatted: String?,
+    val network: String?,
+    val footerOverride: String? = null
+) {
+    companion object {
+        private val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+
+        fun from(displayFiat: String, info: Pos.PaymentInfo?): ReceiptData {
+            val tokenAmount = info?.let { paymentInfo ->
+                val amount = paymentInfo.amount
+                val decimals = paymentInfo.decimals
+                if (amount == null || decimals == null) null
+                else {
+                    val value = amount.toBigDecimalOrNull() ?: return@let null
+                    val divisor = java.math.BigDecimal.TEN.pow(decimals)
+                    value.divide(divisor, decimals, java.math.RoundingMode.HALF_UP)
+                        .stripTrailingZeros()
+                        .toPlainString()
+                }
+            }
+            return ReceiptData(
+                txId = info?.txHash ?: "",
+                date = DATE_FORMAT.format(Date()),
+                displayFiat = displayFiat,
+                tokenSymbol = info?.assetSymbol,
+                tokenAmountFormatted = tokenAmount,
+                network = info?.networkName
+            )
+        }
+
+        fun sample() = ReceiptData(
+            txId = "0xTEST0000000000000000000000000000000000000000",
+            date = DATE_FORMAT.format(Date()),
+            displayFiat = "$1.00 USD",
+            tokenSymbol = "USDC",
+            tokenAmountFormatted = "1.00",
+            network = "Ethereum",
+            footerOverride = "Thank you for your payment!"
+        )
+    }
+}

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptFormatter.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/ReceiptFormatter.kt
@@ -1,0 +1,52 @@
+package com.walletconnect.sample.pos.printer
+
+internal data class ReceiptRow(val label: String, val value: String, val bold: Boolean)
+
+internal object ReceiptFormatter {
+
+    private const val DIVIDER = "--------------------------------"
+    private const val DEFAULT_FOOTER = "Thank you for your payment!"
+    private const val LABEL_WIDTH = 10
+
+    fun rows(receipt: ReceiptData): List<ReceiptRow> = buildList {
+        add(ReceiptRow("ID", receipt.txId, bold = true))
+        add(ReceiptRow("DATE", receipt.date, bold = true))
+        add(ReceiptRow("METHOD", "WalletConnect Pay", bold = true))
+        if (receipt.displayFiat.isNotBlank()) {
+            add(ReceiptRow("AMOUNT", receipt.displayFiat, bold = true))
+        }
+        if (!receipt.tokenSymbol.isNullOrBlank() && !receipt.tokenAmountFormatted.isNullOrBlank()) {
+            add(ReceiptRow("PAID WITH", "${receipt.tokenSymbol} ${receipt.tokenAmountFormatted}", bold = true))
+        }
+        if (!receipt.network.isNullOrBlank()) {
+            add(ReceiptRow("NETWORK", receipt.network, bold = true))
+        }
+    }
+
+    fun footer(receipt: ReceiptData): String = receipt.footerOverride ?: DEFAULT_FOOTER
+
+    fun divider(): String = DIVIDER
+
+    /**
+     * Builds the DantSu ESCPOS markup string for the receipt body (everything *after* the logo).
+     * The logo is printed separately because DantSu image markup requires bitmap conversion that
+     * the driver handles outside this pure formatter.
+     */
+    fun toGenericMarkup(receipt: ReceiptData): String {
+        val sb = StringBuilder()
+        sb.append("[L]\n")
+        sb.append("[C]$DIVIDER\n")
+        sb.append("[L]\n")
+        rows(receipt).forEach { row ->
+            val label = row.label.padEnd(LABEL_WIDTH)
+            val value = if (row.bold) "<b>${row.value}</b>" else row.value
+            sb.append("[L]$label$value\n")
+        }
+        sb.append("[L]\n")
+        sb.append("[C]$DIVIDER\n")
+        sb.append("[L]\n")
+        sb.append("[C]${footer(receipt)}\n")
+        sb.append("[L]\n")
+        return sb.toString()
+    }
+}

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentScreen.kt
@@ -91,6 +91,8 @@ fun PaymentScreen(
                 is PosEvent.PaymentError -> {
                     navigateToErrorScreen(event.error)
                 }
+                is PosEvent.PrintSuccess,
+                is PosEvent.PrintError -> Unit
             }
         }
     }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentSuccessScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/PaymentSuccessScreen.kt
@@ -58,7 +58,7 @@ fun PaymentSuccessScreen(
     displayAmount: String,
     paymentInfo: Pos.PaymentInfo?,
     onNewPayment: () -> Unit,
-    // onPrintReceipt: () -> Unit,
+    onPrintReceipt: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val configuration = LocalConfiguration.current
@@ -140,37 +140,35 @@ fun PaymentSuccessScreen(
 
             Spacer(Modifier.weight(1f))
 
-            // Print receipt button - always dark bg with white text
-            //TODO: Add print receipt button
-            // Box(
-            //     modifier = Modifier
-            //         .fillMaxWidth()
-            //         .height(WCTheme.spacing.spacing12)
-            //         .clip(WCTheme.borderRadius.shapeLarge)
-            //         .background(ButtonDarkBg)
-            //         .clickable(onClick = onPrintReceipt),
-            //     contentAlignment = Alignment.Center
-            // ) {
-            //     Row(
-            //         verticalAlignment = Alignment.CenterVertically,
-            //         horizontalArrangement = Arrangement.Center
-            //     ) {
-            //         Text(
-            //             text = "Print receipt",
-            //             style = WCTheme.typography.bodyLgMedium,
-            //             color = ButtonWhiteText
-            //         )
-            //         Spacer(Modifier.width(WCTheme.spacing.spacing2))
-            //         Icon(
-            //             painter = painterResource(R.drawable.ic_receipt),
-            //             contentDescription = null,
-            //             tint = WCTheme.colors.iconDefault,
-            //             modifier = Modifier.size(16.dp)
-            //         )
-            //     }
-            // }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(WCTheme.spacing.spacing12)
+                    .clip(WCTheme.borderRadius.shapeLarge)
+                    .background(ButtonDarkBg)
+                    .clickable(onClick = onPrintReceipt),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = "Print receipt",
+                        style = WCTheme.typography.bodyLgMedium,
+                        color = ButtonWhiteText
+                    )
+                    Spacer(Modifier.width(WCTheme.spacing.spacing2))
+                    Icon(
+                        painter = painterResource(R.drawable.ic_receipt),
+                        contentDescription = null,
+                        tint = WCTheme.colors.iconDefault,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
 
-            // Spacer(Modifier.height(WCTheme.spacing.spacing3))
+            Spacer(Modifier.height(WCTheme.spacing.spacing3))
 
             // New payment button - always dark bg with white text
             Box(

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
@@ -215,6 +215,17 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(WCTheme.spacing.spacing2))
 
+            // Test printer
+            SettingsItem(
+                label = "Test printer",
+                value = "",
+                showCaret = true,
+                onClick = { viewModel.printTestReceipt() },
+                modifier = Modifier.padding(horizontal = WCTheme.spacing.spacing5)
+            )
+
+            Spacer(Modifier.height(WCTheme.spacing.spacing2))
+
             // SDK Version
             SettingsItem(
                 label = "SDK Version",


### PR DESCRIPTION
## Summary

- Adds a **Print receipt** button to the payment success screen, and a **Test printer** action in Settings, both backed by a `Printer` abstraction in `sample/pos/.../printer/`.
- Uses [DantSu/ESCPOS-ThermalPrinter-Android](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android) (MIT) to drive any paired Bluetooth thermal printer at 48 mm / 203 DPI / 32 chars per line. Receipt layout (logo + label/value rows + footer) mirrors the React Native reference at `reown-com/react-native-examples/dapps/pos-app/utils/printer.ts`.
- Logo is rendered from the existing `ic_wcpay_logo.xml` vector at the target printer width and pre-thresholded to pure 1-bit black/white before the driver hands it off — eliminates the blurry edges you get when DantSu's internal threshold runs over an upscaled raster.
- Adds runtime Bluetooth permission request (SDK 31+) in `POSActivity` and the corresponding manifest entries.

## Screenshots
<img height="300" alt="Screenshot 2026-04-23 at 4 59 08 PM" src="https://github.com/user-attachments/assets/163b1abc-75f7-4a79-999b-cba36553a43b" />


## Test plan

- [x] `./gradlew :sample:pos:assembleDebug` succeeds (lint `abortOnError = true`).
- [x] On an iMin device with a paired thermal printer: tap **Settings → Test printer** and verify the sample receipt prints with a crisp logo and aligned label/value rows.
- [x] Run a real payment, tap **Print receipt** on the success screen, verify the printed ticket matches the on-screen amount/network/asset.
- [ ] On a non-iMin Android device with any paired Bluetooth ESC/POS printer: same Settings → Test printer flow.
- [ ] With Bluetooth disabled or no printer paired: confirm a clear error toast surfaces (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)