### PR TITLE
refactor(sample): show all token balances with filter chips

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
@@ -36,13 +36,8 @@ class ConnectionsViewModel : ViewModel() {
     }
     var displayedAccounts: List<String> = emptyList()
 
-    // USDC Balance state
-    private val _usdcBalances = MutableStateFlow<List<TokenBalance>>(emptyList())
-    val usdcBalances: StateFlow<List<TokenBalance>> = _usdcBalances.asStateFlow()
-
-    // EUROC Balance state
-    private val _eurocBalances = MutableStateFlow<List<TokenBalance>>(emptyList())
-    val eurocBalances: StateFlow<List<TokenBalance>> = _eurocBalances.asStateFlow()
+    private val _balances = MutableStateFlow<List<TokenBalance>>(emptyList())
+    val balances: StateFlow<List<TokenBalance>> = _balances.asStateFlow()
 
     private val _isLoadingBalances = MutableStateFlow(false)
     val isLoadingBalances: StateFlow<Boolean> = _isLoadingBalances.asStateFlow()
@@ -70,29 +65,7 @@ class ConnectionsViewModel : ViewModel() {
                     balances.forEach { balance ->
                         Log.d("Web3Wallet", "Balance: ${balance.symbol} on ${balance.chainId} = ${balance.quantity.numeric}")
                     }
-                    // Filter for USDC on Ethereum, Polygon, and Base
-                    val usdcBalances = balances.filter { balance ->
-                        balance.symbol == "USDC" && balance.chainId in listOf(
-                            "eip155:1",     // Ethereum Mainnet
-                            "eip155:137",   // Polygon
-                            "eip155:8453",  // Base
-                            "eip155:10",    // Optimism
-                            "eip155:42220"  // Celo
-                        )
-                    }
-                    _usdcBalances.value = usdcBalances
-                    Log.d("Web3Wallet", "Filtered USDC balances: $usdcBalances")
-
-                    // Filter for EURC on Ethereum and Base (not deployed on Polygon)
-                    val eurocBalances = balances.filter { balance ->
-                        balance.symbol == "EURC" && balance.chainId in listOf(
-                            "eip155:1",     // Ethereum Mainnet
-                            "eip155:8453",  // Base
-                            "eip155:10"     // Optimism
-                        )
-                    }
-                    _eurocBalances.value = eurocBalances
-                    Log.d("Web3Wallet", "Filtered EURC balances: $eurocBalances")
+                    _balances.value = balances.sortedByDescending { it.value }
                 } else {
                     Log.e("Web3Wallet", "Failed to fetch balances: ${response.code()} - ${response.errorBody()?.string()}")
                 }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/wallets/WalletsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/wallets/WalletsRoute.kt
@@ -3,7 +3,9 @@ package com.reown.sample.wallet.ui.routes.composable_routes.wallets
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
@@ -28,6 +31,9 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,10 +64,18 @@ fun WalletsRoute(
     navController: NavController,
     connectionsViewModel: ConnectionsViewModel,
 ) {
-    val usdcBalances by connectionsViewModel.usdcBalances.collectAsState()
-    val eurocBalances by connectionsViewModel.eurocBalances.collectAsState()
+    val balances by connectionsViewModel.balances.collectAsState()
     val isLoadingBalances by connectionsViewModel.isLoadingBalances.collectAsState()
-    val allBalances = usdcBalances + eurocBalances
+    var selectedSymbols by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    val symbolsWithIcons = remember(balances) {
+        balances
+            .groupBy { it.symbol }
+            .toSortedMap()
+            .map { (symbol, group) -> symbol to group.firstOrNull { !it.iconUrl.isNullOrBlank() }?.iconUrl }
+    }
+    val filteredBalances = if (selectedSymbols.isEmpty()) balances
+    else balances.filter { it.symbol in selectedSymbols }
 
     val pullRefreshState = rememberPullRefreshState(
         refreshing = isLoadingBalances,
@@ -79,7 +93,7 @@ fun WalletsRoute(
                 .fillMaxSize()
                 .pullRefresh(pullRefreshState)
         ) {
-            if (allBalances.isEmpty() && !isLoadingBalances) {
+            if (balances.isEmpty() && !isLoadingBalances) {
                 EmptyWallets()
             } else {
                 LazyColumn(
@@ -89,7 +103,20 @@ fun WalletsRoute(
                     verticalArrangement = Arrangement.spacedBy(spacing.spacing2)
                 ) {
                     item { Spacer(modifier = Modifier.height(spacing.spacing1)) }
-                    items(allBalances) { balance ->
+                    if (symbolsWithIcons.isNotEmpty()) {
+                        item {
+                            TokenFilterChips(
+                                symbolsWithIcons = symbolsWithIcons,
+                                selectedSymbols = selectedSymbols,
+                                onToggle = { symbol ->
+                                    selectedSymbols = if (symbol in selectedSymbols) selectedSymbols - symbol
+                                    else selectedSymbols + symbol
+                                },
+                                onSelectAll = { selectedSymbols = emptySet() }
+                            )
+                        }
+                    }
+                    items(filteredBalances) { balance ->
                         WalletBalanceItem(balance)
                     }
                     item { Spacer(modifier = Modifier.height(spacing.spacing2)) }
@@ -215,6 +242,85 @@ fun WalletBalanceItem(balance: TokenBalance) {
                     Toast.makeText(context, "$chainName address copied", Toast.LENGTH_SHORT).show()
                 },
             tint = colors.iconDefault
+        )
+    }
+}
+
+@Composable
+private fun TokenFilterChips(
+    symbolsWithIcons: List<Pair<String, String?>>,
+    selectedSymbols: Set<String>,
+    onToggle: (String) -> Unit,
+    onSelectAll: () -> Unit,
+) {
+    val spacing = WCTheme.spacing
+    val isAllSelected = selectedSymbols.isEmpty()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(spacing.spacing2),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        FilterChipItem(
+            label = "All",
+            iconUrl = null,
+            selected = isAllSelected,
+            onClick = onSelectAll
+        )
+        symbolsWithIcons.forEach { (symbol, iconUrl) ->
+            FilterChipItem(
+                label = symbol,
+                iconUrl = iconUrl,
+                selected = selectedSymbols.contains(symbol),
+                onClick = { onToggle(symbol) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun FilterChipItem(
+    label: String,
+    iconUrl: String?,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val colors = WCTheme.colors
+    val spacing = WCTheme.spacing
+    val borderRadius = WCTheme.borderRadius
+
+    Row(
+        modifier = Modifier
+            .clip(borderRadius.shapeXLarge)
+            .background(if (selected) colors.bgAccentPrimary.copy(alpha = 0.2f) else colors.foregroundSecondary)
+            .border(
+                width = 1.dp,
+                color = if (selected) colors.borderAccentPrimary else colors.borderSecondary,
+                shape = borderRadius.shapeXLarge
+            )
+            .clickable { onClick() }
+            .padding(horizontal = spacing.spacing3, vertical = spacing.spacing2),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(spacing.spacing1)
+    ) {
+        if (!iconUrl.isNullOrBlank()) {
+            val painter = rememberAsyncImagePainter(model = iconUrl)
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(spacing.spacing4)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Fit
+            )
+        }
+        Text(
+            text = label,
+            style = WCTheme.typography.bodyMdMedium.copy(
+                color = if (selected) colors.textAccentPrimary else colors.textPrimary
+            )
         )
     }
 }


### PR DESCRIPTION
## Summary

Replace the per-symbol `StateFlow` allowlist (USDC, EURC, USDG, PYUSD) in `ConnectionsViewModel` with a **single token-agnostic `balances` flow** populated from the full balance API response, sorted by USD value descending. This mirrors the Swift, Flutter, and RN sample wallets — they already show whatever the balance API returns and never need code edits when a new stablecoin lands.

In `WalletsRoute`, a horizontally-scrollable **filter chip row** is rendered above the list. Chips are derived dynamically from the symbols in the API response, with "All" as the default; tapping a chip narrows the list at runtime. Token icons and chain badges still come from the API (`iconUrl` / `getChainIcon`), no drawables added.

USDG and PYUSD — the original motivation — now appear automatically when the API returns them, alongside any other stablecoin or token the user holds, with **no further code change needed for the next one**.

## Data flow

```mermaid
flowchart LR
    A[rpc.walletconnect.org<br/>/v1/account/:addr/balance] -->|all balances| B[ConnectionsViewModel.fetchBalances]
    B -->|sorted by value desc| C[balances: StateFlow]
    C --> D[WalletsRoute]
    D --> E[TokenFilterChips<br/>derived from symbols]
    D --> F[LazyColumn<br/>filtered by selected chips]
    E -.user toggles.-> F
```

## Test plan

- [ ] `./gradlew :sample:wallet:assembleDebug` succeeds (verified locally)
- [ ] On a funded EVM address, all returned tokens render in the Wallets tab, sorted by USD value descending
- [ ] Filter chips appear above the list, "All" selected by default; tapping a chip narrows the list, tapping multiple chips OR-filters; tapping "All" clears the filter
- [ ] USDG and PYUSD appear automatically when the API returns them — no per-symbol code path
- [ ] Pull-to-refresh continues to work; logcat tag `Web3Wallet` still prints every balance the API returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)