### PR TITLE
fix(sample/wallet): include broadcast tx hash in WCPay signatures

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -451,6 +451,7 @@ class PaymentViewModel : ViewModel() {
                         val txHash = PaymentTransactionUtil.sendTransactionWithFreshFees(action.action)
                         Log.d("PaymentViewModel", "Approval tx broadcast: $txHash")
                         PaymentTransactionUtil.waitForTransactionConfirmation(action.action.chainId, txHash)
+                        signatures.add(txHash)
                         _uiState.value = PaymentUiState.Processing(
                             message = "Finalizing your payment...",
                             paymentInfo = storedPaymentInfo

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -424,10 +424,11 @@ class PaymentViewModel : ViewModel() {
      *
      * Iterates `pendingWalletRpcActions` in order and dispatches each one:
      *  - `eth_sendTransaction` → broadcast via `PaymentTransactionUtil` with fresh
-     *    gas fees, then wait for confirmation. Not added to `signatures`.
+     *    gas fees, wait for confirmation, then append the tx hash to `signatures`.
      *  - `eth_signTypedData_*` / `personal_sign` → signed via `PaymentSigner`
      *    and appended to `signatures`.
-     * Only typed-data signatures are passed to `confirmPayment`.
+     * `signatures` is passed to `confirmPayment` with one entry per required action,
+     * preserving order.
      */
     private suspend fun executePayment() {
         val paymentId = currentPaymentId ?: return


### PR DESCRIPTION
## Summary

- Native ETH payments via WCPay (e.g., ETH on Base) only produce a single `eth_sendTransaction` action. The wallet broadcasts that tx itself, then calls `confirmPayment` — but the broadcasted tx hash was never communicated back, so `signatures` was empty.
- The yttrium-wcpay backend rejects this with `400: Validation error: Next result not present` because its result chain expects one entry per required action.
- Fix: append the broadcasted tx hash to `signatures` at the matching action index, so `signatures.size == pendingWalletRpcActions.size`.

## Action → signature mapping after this change

```mermaid
flowchart LR
    A[pendingWalletRpcActions] --> B{action.method}
    B -->|eth_sendTransaction| C[broadcast tx + wait for confirmation]
    C --> D[signatures += txHash]
    B -->|eth_signTypedData_* / personal_sign| E[PaymentSigner.signWalletRpcAction]
    E --> F[signatures += signature]
    D --> G[confirmPayment&#40;signatures&#41;]
    F --> G
```

## Test plan

- [ ] Native ETH payment on Base completes successfully (was failing with `400: Validation error: Next result not present`)
- [ ] USDC payment on Base/OP/Polygon/Mainnet (with first-time approval) still completes — verify the approval-step `eth_sendTransaction` followed by typed-data signature both reach the backend in the right order
- [ ] USDC payment with no approval required still completes
- [ ] Inspect logs to confirm `Approval tx broadcast: 0x…` appears before `confirmPayment` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)