### PR TITLE
fix(sign): tolerate non-string values in scopedProperties

### DIFF
--- a/core/android/src/main/kotlin/com/reown/android/internal/common/json_rpc/domain/relay/RelayJsonRpcInteractor.kt
+++ b/core/android/src/main/kotlin/com/reown/android/internal/common/json_rpc/domain/relay/RelayJsonRpcInteractor.kt
@@ -543,7 +543,12 @@ internal class RelayJsonRpcInteractor(
         ) {
             serializer.deserialize(clientJsonRpc.method, subscription.decryptedMessage)?.let { params ->
                 _clientSyncJsonRpc.emit(subscription.toWCRequest(clientJsonRpc, params, TransportType.RELAY))
-            } ?: handleError("JsonRpcInteractor: Unknown request params")
+            } ?: handleError(
+                "JsonRpcInteractor: Unknown request params" +
+                    " | method=${clientJsonRpc.method}" +
+                    " | topic=${subscription.topic.value}" +
+                    " | body=${subscription.decryptedMessage}"
+            )
         }
     }
 

--- a/protocol/sign/src/main/kotlin/com/reown/sign/common/model/vo/clientsync/session/params/SignParams.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/common/model/vo/clientsync/session/params/SignParams.kt
@@ -4,10 +4,14 @@ package com.reown.sign.common.model.vo.clientsync.session.params
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import org.koin.core.qualifier.named
+import com.reown.android.internal.common.di.AndroidCommonDITags
 import com.reown.android.internal.common.model.Namespace
 import com.reown.android.internal.common.model.RelayProtocolOptions
 import com.reown.android.internal.common.model.SessionProposer
 import com.reown.android.internal.common.model.params.CoreSignParams
+import com.reown.android.internal.common.wcKoinApp
 import com.reown.sign.common.model.vo.clientsync.common.PayloadParams
 import com.reown.sign.common.model.vo.clientsync.common.ProposalRequests
 import com.reown.sign.common.model.vo.clientsync.common.ProposalRequestsResponses
@@ -16,6 +20,21 @@ import com.reown.sign.common.model.vo.clientsync.common.SessionParticipant
 import com.reown.sign.common.model.vo.clientsync.session.payload.SessionEventVO
 import com.reown.sign.common.model.vo.clientsync.session.payload.SessionRequestVO
 import com.reown.utils.DefaultId
+
+/**
+ * `scopedProperties` is declared as Map<String, Any>? to tolerate wallets (e.g. Uniswap Wallet)
+ * that send non-string nested JSON values like `{"eip155:56": {"atomic": {"status": "ready"}}}`.
+ * Downstream storage / VO layers still expect Map<String, String>?, so call this helper to flatten
+ * non-string values to their JSON representation before passing on.
+ */
+@JvmSynthetic
+internal fun Map<String, Any>?.toScopedPropertiesStringMap(): Map<String, String>? =
+    this?.mapValues { (_, v) ->
+        if (v is String) v else runCatching {
+            val moshi = wcKoinApp.koin.get<Moshi.Builder>(named(AndroidCommonDITags.MOSHI)).build()
+            moshi.adapter(Any::class.java).toJson(v)
+        }.getOrElse { v.toString() }
+    }
 
 internal sealed class SignParams : CoreSignParams() {
 
@@ -32,7 +51,7 @@ internal sealed class SignParams : CoreSignParams() {
         @param:Json(name = "sessionProperties")
         val properties: Map<String, String>?,
         @param:Json(name = "scopedProperties")
-        val scopedProperties: Map<String, String>?,
+        val scopedProperties: Map<String, Any>?,
         @param:Json(name = "expiryTimestamp")
         val expiryTimestamp: Long?,
         @param:Json(name = "requests")
@@ -66,7 +85,7 @@ internal sealed class SignParams : CoreSignParams() {
         @param:Json(name = "sessionProperties")
         val properties: Map<String, String>?,
         @param:Json(name = "scopedProperties")
-        val scopedProperties: Map<String, String>?,
+        val scopedProperties: Map<String, Any>?,
         @param:Json(name = "proposalRequestsResponses")
         val proposalRequestsResponses: ProposalRequestsResponses?,
     ) : SignParams()

--- a/protocol/sign/src/main/kotlin/com/reown/sign/common/model/vo/sequence/SessionVO.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/common/model/vo/sequence/SessionVO.kt
@@ -12,6 +12,7 @@ import com.reown.foundation.common.model.PublicKey
 import com.reown.foundation.common.model.Topic
 import com.reown.sign.common.model.vo.clientsync.common.SessionParticipant
 import com.reown.sign.common.model.vo.clientsync.session.params.SignParams
+import com.reown.sign.common.model.vo.clientsync.session.params.toScopedPropertiesStringMap
 import com.reown.sign.common.model.vo.proposal.ProposalVO
 import com.reown.sign.engine.model.EngineDO
 import com.reown.sign.engine.model.mapper.toMapOfNamespacesVOSession
@@ -98,7 +99,7 @@ internal data class SessionVO(
                 requiredNamespaces = requiredNamespaces,
                 optionalNamespaces = optionalNamespaces,
                 properties = settleParams.properties,
-                scopedProperties = settleParams.scopedProperties,
+                scopedProperties = settleParams.scopedProperties.toScopedPropertiesStringMap(),
                 isAcknowledged = true,
                 pairingTopic = pairingTopic,
                 transportType = TransportType.RELAY

--- a/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/mapper/EngineMapper.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/mapper/EngineMapper.kt
@@ -25,6 +25,7 @@ import com.reown.sign.common.model.vo.clientsync.common.ProposalRequests
 import com.reown.sign.common.model.vo.clientsync.common.ProposalRequestsResponses
 import com.reown.sign.common.model.vo.clientsync.common.Requester
 import com.reown.sign.common.model.vo.clientsync.session.params.SignParams
+import com.reown.sign.common.model.vo.clientsync.session.params.toScopedPropertiesStringMap
 import com.reown.sign.common.model.vo.proposal.ProposalVO
 import com.reown.sign.common.model.vo.sequence.SessionVO
 import com.reown.sign.engine.model.EngineDO
@@ -62,7 +63,7 @@ internal fun SignParams.SessionProposeParams.toEngineDO(topic: Topic): EngineDO.
         proposerPublicKey = proposer.publicKey,
         relayProtocol = relays.first().protocol,
         relayData = relays.first().data,
-        scopedProperties = scopedProperties,
+        scopedProperties = scopedProperties.toScopedPropertiesStringMap(),
         requests = if (requests != null) {
             EngineDO.ProposalRequests(authentication = requests.authentication?.map { it.toEngineDO() })
         } else null
@@ -85,7 +86,7 @@ internal fun SignParams.SessionProposeParams.toVO(topic: Topic, requestId: Long)
         relayProtocol = relays.first().protocol,
         relayData = relays.first().data,
         expiry = if (expiryTimestamp != null) Expiry(expiryTimestamp) else null,
-        scopedProperties = scopedProperties,
+        scopedProperties = scopedProperties.toScopedPropertiesStringMap(),
         requests = ProposalRequests(authentication = requests?.authentication ?: emptyList())
     )
 


### PR DESCRIPTION
## Summary

  Wallets that send EIP-5792 capability hints (observed with **Uniswap Wallet**) put nested JSON objects inside `scopedProperties` on
  `wc_sessionSettle`, e.g.:

  ```json
  "scopedProperties": {
    "eip155:56": { "atomic": { "status": "ready" } }
  }
  ```

  The SDK declares the field as `Map<String, String>?`, so Moshi silently fails to deserialize the params. `RelayJsonRpcInteractor` then emits:

  ```
  JsonRpcInteractor: Unknown request params
  ```

  The dApp never sees `onSessionApproved` and the connection appears stuck even though the relay round-trip succeeded.

  ## Fix

  - Widen `SessionSettleParams.scopedProperties` and `SessionProposeParams.scopedProperties` to `Map<String, Any>?` at the JSON-RPC boundary.
  - Add `toScopedPropertiesStringMap()` helper that flattens non-string values back to JSON strings via Moshi.
  - Apply the helper at the three conversion sites where wire params cross into the SDK's internal model: `SessionVO.createAcknowledgedSession`,
  `EngineMapper.toEngineDO`, `EngineMapper.toVO`.

  Downstream storage (SQLDelight, `ColumnAdapter<Map<String, String>, String>`, `SessionVO`, `ProposalVO`, `EngineDO`) keeps `Map<String, String>?` —
  **no schema migration** required.

  ## Drive-by diagnostic improvement

  Include `method`, `topic`, and `body` in the `Unknown request params` error so this class of protocol-mismatch is debuggable from logcat without
  patching the SDK locally.

  ## Reproduction

  1. Configure a dApp with `linkMode = false`.
  2. Connect to a wallet that sends EIP-5792 `atomic` capability hints in `scopedProperties` (Uniswap Wallet on BSC was the original observation).
  3. Approve the session in the wallet.
  4. Before this fix: dApp logs `JsonRpcInteractor: Unknown request params` and `onSessionApproved` never fires.
  5. After this fix: session is approved normally and the capability hint is preserved as a JSON string in the stored namespaces.

  ## Test plan

  - [x] Connect to a wallet that does NOT send nested `scopedProperties` (existing flow — must keep working).
  - [x] Connect to a wallet that sends nested `scopedProperties` (Uniswap Wallet) — session approve succeeds.
  - [x] Outbound: dApp setting `scopedProperties = mapOf("eip155:1" to "value")` still serializes correctly.
  - [ ] Existing unit/instrumented tests for sign protocol pass.