### PR TITLE
fix(sample/pos): make wallet theme bottom sheet scrollable on small screens

### DIFF
--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -40,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.walletconnect.sample.pos.ui.theme.WCTheme
@@ -310,9 +312,11 @@ private fun WalletThemeBottomSheet(
     onSelect: (PosVariant) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val maxSheetHeight = (LocalConfiguration.current.screenHeightDp * 0.85f).dp
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(max = maxSheetHeight)
             .verticalScroll(rememberScrollState())
             .padding(WCTheme.spacing.spacing5)
     ) {


### PR DESCRIPTION
## Summary

- The wallet-theme picker (Settings → Wallet theme) couldn't reach its last entries on small POS devices — *iMin*, *Money 20/20*, *xMoney* were clipped off-screen with no way to scroll to them.
- Root cause: the `Column` in `WalletThemeBottomSheet` was wrapped in `verticalScroll`, but Material 1's `ModalBottomSheetLayout` doesn't impose a max-height on `sheetContent`. With 11 `PosVariant` entries × ~76dp each (~850dp), the Column laid out at its full intrinsic height and ran off the bottom of the screen. `verticalScroll` had no overflow to scroll through.
- Fix: bound the Column to `heightIn(max = screenHeight * 0.85f)` so `verticalScroll` has a finite viewport vs. taller content. Tall screens are unaffected — content still wraps to fit when it fits.

```mermaid
flowchart TD
    A[ModalBottomSheetLayout sheetContent] --> B[Column with verticalScroll]
    B -- before: no maxHeight --> C[Column lays out at ~850dp]
    C --> D[Content runs off screen, no scroll overflow]
    B -- after: heightIn max 0.85 * screenHeight --> E[Column bounded to viewport]
    E --> F[verticalScroll has overflow, scrolling works]
```

## Test plan

- [ ] Open POS sample on a small device / small emulator, navigate to Settings → Wallet theme.
- [ ] Verify all 11 entries (None … xMoney) are reachable by scrolling.
- [ ] Verify swipe-down still dismisses the sheet from the top of the content (nested-scroll handoff to `ModalBottomSheetLayout`).
- [ ] On a tall device, verify the sheet still wraps to content height (does not unnecessarily occupy 85% of the screen when content fits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)