### PR TITLE
fix(sample/pos): guard NFC HCE setup on devices without Host Card Emulation

### DIFF
--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/nfc/NfcManager.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/nfc/NfcManager.kt
@@ -75,7 +75,13 @@ internal object NfcManager {
         foregroundActivityRef = activity?.let { WeakReference(it) }
         val ctx = appContext ?: return
         val adapter = NfcAdapter.getDefaultAdapter(ctx) ?: return
-        val cardEmulation = CardEmulation.getInstance(adapter)
+        if (!ctx.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION)) return
+        val cardEmulation = try {
+            CardEmulation.getInstance(adapter)
+        } catch (e: UnsupportedOperationException) {
+            Timber.w(e, "NFC: HCE not supported on this device")
+            return
+        }
         val component = ComponentName(ctx, NdefHostApduService::class.java)
         if (activity != null) {
             cardEmulation.setPreferredService(activity, component)


### PR DESCRIPTION
## Summary

Fixes a crash in `POSActivity.onResume` on devices that have an NFC adapter but do not support Host Card Emulation (HCE).

```
FATAL EXCEPTION: main
java.lang.UnsupportedOperationException
    at android.nfc.cardemulation.CardEmulation.getInstance(CardEmulation.java:164)
    at com.walletconnect.sample.pos.nfc.NfcManager.setActivity(NfcManager.kt:78)
    at com.walletconnect.sample.pos.POSActivity.onResume(POSActivity.kt:76)
```

`CardEmulation.getInstance(adapter)` throws `UnsupportedOperationException` on devices without `FEATURE_NFC_HOST_CARD_EMULATION`. The existing `isAvailable` getter already checks this feature, but `setActivity` only verified that an `NfcAdapter` existed.

## Changes

- `NfcManager.setActivity` now bails out early when `FEATURE_NFC_HOST_CARD_EMULATION` is missing.
- Defensively wraps `CardEmulation.getInstance` in a try/catch and logs the exception if it still fires on a quirky OEM build.

```mermaid
flowchart TD
    A[POSActivity.onResume] --> B[NfcManager.setActivity]
    B --> C{appContext null?}
    C -- yes --> X[return]
    C -- no --> D{NfcAdapter available?}
    D -- no --> X
    D -- yes --> E{HCE feature supported?}
    E -- no --> X
    E -- yes --> F[try CardEmulation.getInstance]
    F -- UnsupportedOperationException --> G[log warning + return]
    F -- ok --> H[setPreferredService / unsetPreferredService]
```

## Test plan

- [ ] Install POS sample on a device without HCE (e.g. emulator or NFC-less tablet) and confirm the app no longer crashes on resume.
- [ ] Install on a device with HCE and confirm NFC tag emulation still routes to `NdefHostApduService` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)