### PR TITLE
feat(sample/pos): co-branded receipt logo + unlock Money 20/20 & xMoney themes

### DIFF
--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/POSViewModel.kt
@@ -164,7 +164,7 @@ class POSViewModel(application: Application) : AndroidViewModel(application) {
 
     private suspend fun executePrint(receipt: ReceiptData, isTest: Boolean, source: String) {
         PosLogStore.info("Print receipt requested", source = source)
-        printerManager.print(receipt).fold(
+        printerManager.print(receipt, _selectedVariant.value).fold(
             onSuccess = {
                 PosLogStore.info("Receipt printed", source = source)
                 _posEventsFlow.emit(PosEvent.PrintSuccess(isTest))

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/model/PosVariant.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/model/PosVariant.kt
@@ -15,7 +15,11 @@ enum class PosVariant(
     val accentColor: Color?,
     val textInvertOverride: Color?,
     val successTextColor: Color,
-    val defaultTheme: ThemeMode?
+    val defaultTheme: ThemeMode?,
+    // When false, the variant's theme is locked and the Theme selector is disabled in Settings.
+    // When true, devs can still switch the theme manually (defaultTheme is only the initial value).
+    // Mirrors the `allowThemeToggle` flag in the React Native POS.
+    val allowThemeToggle: Boolean = true
 ) {
     DEFAULT(
         displayName = "None",
@@ -45,7 +49,8 @@ enum class PosVariant(
         accentColor = Color(0xFFFFEF46),
         textInvertOverride = Color(0xFF202020),
         successTextColor = Color(0xFF202020),
-        defaultTheme = ThemeMode.DARK
+        defaultTheme = ThemeMode.DARK,
+        allowThemeToggle = false
     ),
     BINANCE(
         displayName = "Binance",
@@ -55,7 +60,8 @@ enum class PosVariant(
         accentColor = Color(0xFFFCD533),
         textInvertOverride = Color(0xFF202020),
         successTextColor = Color(0xFF202020),
-        defaultTheme = ThemeMode.LIGHT
+        defaultTheme = ThemeMode.LIGHT,
+        allowThemeToggle = false
     ),
     PHANTOM(
         displayName = "Phantom",
@@ -65,7 +71,8 @@ enum class PosVariant(
         accentColor = Color(0xFFAB9FF2),
         textInvertOverride = null,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.LIGHT
+        defaultTheme = ThemeMode.LIGHT,
+        allowThemeToggle = false
     ),
     SOLANA(
         displayName = "Solana",
@@ -75,7 +82,8 @@ enum class PosVariant(
         accentColor = Color(0xFF9945FF),
         textInvertOverride = Color.White,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.DARK
+        defaultTheme = ThemeMode.DARK,
+        allowThemeToggle = false
     ),
     LEDGER(
         displayName = "Ledger",
@@ -85,7 +93,8 @@ enum class PosVariant(
         accentColor = Color(0xFF000000),
         textInvertOverride = null,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.LIGHT
+        defaultTheme = ThemeMode.LIGHT,
+        allowThemeToggle = false
     ),
     TREZOR(
         displayName = "Trezor",
@@ -95,7 +104,8 @@ enum class PosVariant(
         accentColor = Color(0xFF60E198),
         textInvertOverride = Color(0xFF1F1F1F),
         successTextColor = Color(0xFF1F1F1F),
-        defaultTheme = ThemeMode.LIGHT
+        defaultTheme = ThemeMode.LIGHT,
+        allowThemeToggle = false
     ),
     IMIN(
         displayName = "iMin",
@@ -105,7 +115,8 @@ enum class PosVariant(
         accentColor = Color(0xFF000000),
         textInvertOverride = null,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.LIGHT
+        defaultTheme = ThemeMode.LIGHT,
+        allowThemeToggle = false
     ),
     MONEY2020(
         displayName = "Money 20/20",
@@ -115,7 +126,7 @@ enum class PosVariant(
         accentColor = null,
         textInvertOverride = null,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.DARK
+        defaultTheme = ThemeMode.LIGHT
     ),
     XMONEY(
         displayName = "xMoney",
@@ -125,7 +136,7 @@ enum class PosVariant(
         accentColor = null,
         textInvertOverride = null,
         successTextColor = Color.White,
-        defaultTheme = ThemeMode.DARK
+        defaultTheme = ThemeMode.LIGHT
     )
 }
 

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
@@ -4,31 +4,71 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.drawable.Drawable
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.DrawableCompat
 import com.walletconnect.sample.pos.R
+import com.walletconnect.sample.pos.model.PosVariant
 
 internal class PrinterManager(private val context: Context) {
 
     private val printer: Printer = GenericBluetoothPrinter(context)
 
-    suspend fun print(receipt: ReceiptData): Result<Unit> = printer.print(receipt, logoBitmap())
+    suspend fun print(receipt: ReceiptData, variant: PosVariant): Result<Unit> =
+        printer.print(receipt, logoBitmap(variant))
 
-    private fun logoBitmap(): Bitmap {
-        val drawable = AppCompatResources.getDrawable(context, R.drawable.ic_wcpay_logo)
-            ?: error("Receipt logo drawable missing: ic_wcpay_logo")
-        val srcWidth = drawable.intrinsicWidth.takeIf { it > 0 } ?: LOGO_TARGET_WIDTH
-        val srcHeight = drawable.intrinsicHeight.takeIf { it > 0 } ?: (LOGO_TARGET_WIDTH / 3)
-        val targetHeight = (LOGO_TARGET_WIDTH * srcHeight / srcWidth).coerceAtLeast(1)
+    // A single element of the co-branded lockup, sized in dp (matches BrandLogoRow proportions).
+    private data class LogoElement(val drawableRes: Int, val widthDp: Int, val heightDp: Int)
 
-        // Render the vector at target printer resolution onto a white background — vectors stay crisp
-        // at any size, unlike upscaling a small raster which produces blurry edges after thresholding.
-        val bitmap = Bitmap.createBitmap(LOGO_TARGET_WIDTH, targetHeight, Bitmap.Config.ARGB_8888)
+    /**
+     * Builds the receipt header logo as a single monochrome bitmap, mirroring the on-screen
+     * [com.walletconnect.sample.pos.components.BrandLogoRow]: WCPay logo, and when the selected
+     * variant carries a partner logo, a "+" separator followed by the partner logo.
+     *
+     * Every drawable is tinted black before drawing — the partner logos are authored white for the
+     * dark-theme UI, so without tinting they would render white-on-white and print blank.
+     */
+    private fun logoBitmap(variant: PosVariant): Bitmap {
+        val elements = buildList {
+            add(LogoElement(R.drawable.ic_wcpay_logo, WCPAY_WIDTH_DP, WCPAY_HEIGHT_DP))
+            variant.partnerLogoRes?.let { partnerRes ->
+                add(LogoElement(R.drawable.ic_plus_header, PLUS_SIZE_DP, PLUS_SIZE_DP))
+                add(LogoElement(partnerRes, variant.partnerLogoWidthDp, variant.partnerLogoHeightDp))
+            }
+        }
+
+        // Lay out horizontally in dp, then scale uniformly so the whole lockup fits the print head.
+        val totalWidthDp = elements.sumOf { it.widthDp } + GAP_DP * (elements.size - 1)
+        val totalHeightDp = elements.maxOf { it.heightDp }
+        val scale = LOGO_TARGET_WIDTH.toFloat() / totalWidthDp
+
+        val canvasWidth = LOGO_TARGET_WIDTH
+        val canvasHeight = (totalHeightDp * scale).toInt().coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(canvasWidth, canvasHeight, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         canvas.drawColor(Color.WHITE)
-        drawable.setBounds(0, 0, LOGO_TARGET_WIDTH, targetHeight)
-        drawable.draw(canvas)
+
+        var xDp = 0
+        for (element in elements) {
+            val drawable = loadBlackTinted(element.drawableRes)
+            val left = (xDp * scale).toInt()
+            val width = (element.widthDp * scale).toInt().coerceAtLeast(1)
+            val height = (element.heightDp * scale).toInt().coerceAtLeast(1)
+            val top = ((canvasHeight - height) / 2).coerceAtLeast(0) // vertically center against tallest
+            drawable.setBounds(left, top, left + width, top + height)
+            drawable.draw(canvas)
+            xDp += element.widthDp + GAP_DP
+        }
 
         return thresholdToMonochrome(bitmap)
+    }
+
+    private fun loadBlackTinted(drawableRes: Int): Drawable {
+        val drawable = AppCompatResources.getDrawable(context, drawableRes)
+            ?.mutate()
+            ?: error("Receipt logo drawable missing: $drawableRes")
+        DrawableCompat.setTint(drawable, Color.BLACK)
+        return drawable
     }
 
     private fun thresholdToMonochrome(src: Bitmap): Bitmap {
@@ -53,5 +93,11 @@ internal class PrinterManager(private val context: Context) {
         // Target a width that fits comfortably inside the 384-dot, 48mm @ 203 DPI thermal head
         private const val LOGO_TARGET_WIDTH = 320
         private const val LUMA_THRESHOLD = 160
+
+        // Lockup proportions in dp — mirror BrandLogoRow (WCPay 60x18, plus 20x20, spacing2 = 8dp gap)
+        private const val WCPAY_WIDTH_DP = 60
+        private const val WCPAY_HEIGHT_DP = 18
+        private const val PLUS_SIZE_DP = 20
+        private const val GAP_DP = 8
     }
 }

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/printer/PrinterManager.kt
@@ -60,7 +60,12 @@ internal class PrinterManager(private val context: Context) {
             xDp += element.widthDp + GAP_DP
         }
 
-        return thresholdToMonochrome(bitmap)
+        // thresholdToMonochrome returns a fresh bitmap; recycle this intermediate canvas bitmap.
+        return try {
+            thresholdToMonochrome(bitmap)
+        } finally {
+            bitmap.recycle()
+        }
     }
 
     private fun loadBlackTinted(drawableRes: Int): Drawable {

--- a/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
+++ b/sample/pos/src/main/kotlin/com/walletconnect/sample/pos/screens/SettingsScreen.kt
@@ -83,7 +83,7 @@ fun SettingsScreen(
     val sheetState = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
     val scope = rememberCoroutineScope()
     var activeSheet by remember { mutableStateOf(ActiveSheet.CURRENCY) }
-    val isThemeDisabled = selectedVariant.defaultTheme != null
+    val isThemeDisabled = !selectedVariant.allowThemeToggle
 
     ModalBottomSheetLayout(
         sheetState = sheetState,


### PR DESCRIPTION
The printed receipt header now renders a co-branded lockup driven by the selected `PosVariant` — WCPay logo + `+` + partner logo — mirroring the on-screen `BrandLogoRow`, with every drawable tinted black so the white-authored partner logos (e.g. Money 20/20) print correctly on thermal paper instead of blank. The Money 20/20 and xMoney variants now default to the light theme instead of dark.

A new `allowThemeToggle` flag on `PosVariant` (default `true`, mirroring the React Native POS) decouples the theme lock from `defaultTheme`, so devs can manually switch the theme on Money 20/20 and xMoney while the other brand variants stay locked. `SettingsScreen` now gates the Theme selector on this flag.

Verified by building `:sample:pos:assembleDebug`; receipt logo rendering needs manual confirmation with a paired Bluetooth thermal printer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)