### PR TITLE
feat(sample/wallet): show multi-chain balances with native address rows

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/blockchain/BalanceApiService.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/blockchain/BalanceApiService.kt
@@ -10,7 +10,8 @@ interface BalanceApiService {
     suspend fun getBalance(
         @Path("address") address: String,
         @Query("projectId") projectId: String,
-        @Query("currency") currency: String = "usd"
+        @Query("currency") currency: String = "usd",
+        @Query("chainId") chainId: String? = null
     ): Response<BalanceResponse>
 }
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/blockchain/BalanceUtils.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/blockchain/BalanceUtils.kt
@@ -1,0 +1,117 @@
+package com.reown.sample.wallet.blockchain
+
+import com.reown.sample.wallet.domain.account.TONAccountDelegate
+import com.reown.sample.wallet.domain.account.TronAccountDelegate
+import com.reown.sample.wallet.ui.routes.dialog_routes.transaction.Chain
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+import kotlin.math.ceil
+import kotlin.math.log10
+
+private const val TRUST_WALLET_LOGO_BASE =
+    "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains"
+
+private fun nativeToken(
+    name: String,
+    symbol: String,
+    chainId: String,
+    decimals: String,
+    logo: String,
+) = TokenBalance(
+    name = name,
+    symbol = symbol,
+    chainId = chainId,
+    address = null,
+    value = 0.0,
+    price = 0.0,
+    quantity = TokenQuantity(decimals = decimals, numeric = "0"),
+    iconUrl = "$TRUST_WALLET_LOGO_BASE/$logo/info/logo.png"
+)
+
+/**
+ * Mainnet native tokens always shown (with a zero-balance default) so the user
+ * can always read/copy the account address even when the balance API omits the
+ * native row. The chainId matches the chainId used to fetch that chain so a real
+ * API balance overrides this zero default.
+ */
+internal val mainnetNativeTokens: List<TokenBalance> = listOf(
+    nativeToken("Ethereum", "ETH", "eip155:1", "18", "ethereum"),
+    nativeToken("Solana", "SOL", Chain.SOLANA.id, "9", "solana"),
+    nativeToken("Sui", "SUI", Chain.SUI.id, "9", "sui"),
+    nativeToken("TON", "TON", TONAccountDelegate.mainnet, "9", "ton"),
+    nativeToken("TRON", "TRX", TronAccountDelegate.mainnet, "6", "tron"),
+)
+
+private val nativeChainIds: Set<String> = mainnetNativeTokens.map { it.chainId }.toSet()
+
+/**
+ * Formats a token quantity for display: two decimals normally, but for small
+ * amounts (< 0.01) it keeps adding leading zeros until the first non-zero decimal
+ * digit (e.g. 0.00034 -> "0.0003") so the value isn't shown as "0.00".
+ */
+internal fun formatTokenAmount(numeric: String): String {
+    val num = numeric.toDoubleOrNull() ?: return numeric
+    if (num <= 0.0) return "0"
+
+    val symbols = DecimalFormatSymbols(Locale.US)
+    val pattern = if (num >= 0.01) {
+        "#,##0.00"
+    } else {
+        // Position of the first significant decimal digit.
+        val decimals = ceil(-log10(num)).toInt().coerceAtLeast(2)
+        "0." + "0".repeat(decimals)
+    }
+    return DecimalFormat(pattern, symbols).apply { roundingMode = RoundingMode.HALF_UP }.format(num)
+}
+
+/** Symbols of known spam/airdrop tokens to hide, matched case-insensitively. */
+private val spamSymbols: Set<String> = setOf(
+    "MANTRA POS", "AMPAR", "ACHIVX", "BASED", "GT", "MY"
+)
+
+/** Domain-like segment ("name.tld") that legitimate token symbols never contain. */
+private val domainRegex = Regex("[a-z0-9][a-z0-9-]*\\.[a-z]{2,}", RegexOption.IGNORE_CASE)
+
+/**
+ * Detects scam/airdrop tokens that abuse the symbol field to advertise a website
+ * (e.g. "USD0 [www.usual.finance]", "ecAVAX - https://invest...", "www.2base.cfd")
+ * or that match a known spam symbol blocklist.
+ */
+internal fun isSpam(token: TokenBalance): Boolean {
+    val symbol = token.symbol
+    val lower = symbol.lowercase()
+    if (lower.contains("http://") || lower.contains("https://") ||
+        lower.contains("www.") || lower.contains("://")
+    ) return true
+    if (domainRegex.containsMatchIn(symbol)) return true
+    if (symbol.contains("[") || symbol.contains("]")) return true
+    if (symbol.trim().uppercase() in spamSymbols) return true
+    return false
+}
+
+/**
+ * Filters out dust (zero-value, zero-quantity non-native tokens) and ensures a
+ * zero-balance native row exists for each [availableNativeChainIds] chain so its
+ * address stays visible. Returns the list sorted by USD value descending.
+ */
+internal fun processBalances(
+    apiBalances: List<TokenBalance>,
+    availableNativeChainIds: Set<String>,
+): List<TokenBalance> {
+    val filtered = apiBalances.filter { b ->
+        b.value > 0 ||
+            (b.address == null && b.chainId in nativeChainIds) ||
+            (b.quantity.numeric.toDoubleOrNull() ?: 0.0) > 0
+    }
+
+    val result = filtered.toMutableList()
+    for (native in mainnetNativeTokens) {
+        if (native.chainId !in availableNativeChainIds) continue
+        val hasNative = result.any { it.chainId == native.chainId && it.address == null }
+        if (!hasNative) result.add(native)
+    }
+
+    return result.sortedByDescending { it.value }
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
@@ -20,6 +20,7 @@ import com.reown.sample.wallet.domain.account.TONAccountDelegate
 import com.reown.sample.wallet.domain.account.TronAccountDelegate
 import com.reown.sample.wallet.ui.routes.dialog_routes.transaction.Chain
 import com.reown.walletkit.client.WalletKit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -53,11 +54,22 @@ class ConnectionsViewModel : ViewModel() {
 
     private val balanceApiService = createBalanceApiService()
 
-    // Non-EVM addresses (Solana/Sui/TON/Tron) derived once, keyed by CAIP-2
-    // namespace. Deriving them is crypto/FFI work that must not run per render or
-    // per refresh; the underlying keys only change on wallet import, which
-    // recreates this view model.
-    private val nonEvmAddresses: Map<String, String> = buildMap {
+    // Non-EVM addresses (Solana/Sui/TON/Tron) keyed by CAIP-2 namespace, derived
+    // off the main thread (it's crypto/FFI work — TON even spins up a client) and
+    // cached. The underlying keys only change on wallet import, which recreates
+    // this view model. @Volatile so addressFor() reads the populated map from the
+    // main thread once the IO derivation completes.
+    @Volatile
+    private var nonEvmAddresses: Map<String, String> = emptyMap()
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            nonEvmAddresses = deriveNonEvmAddresses()
+            fetchBalances()
+        }
+    }
+
+    private fun deriveNonEvmAddresses(): Map<String, String> = buildMap {
         runCatching { SolanaAccountDelegate.getSolanaPubKeyForKeyPair() }.getOrNull()
             ?.takeIf { it.isNotBlank() }?.let { put("solana", it) }
         runCatching { SuiAccountDelegate.address }.getOrNull()
@@ -66,10 +78,6 @@ class ConnectionsViewModel : ViewModel() {
             ?.takeIf { it.isNotBlank() }?.let { put("ton", it) }
         runCatching { TronAccountDelegate.address }.getOrNull()
             ?.takeIf { it.isNotBlank() }?.let { put("tron", it) }
-    }
-
-    init {
-        fetchBalances()
     }
 
     /** Address shown and copied for a balance row, by the token's CAIP-2 namespace. */
@@ -128,12 +136,15 @@ class ConnectionsViewModel : ViewModel() {
             )
             if (response.isSuccessful) {
                 val balances = response.body()?.balances ?: emptyList()
-                Log.d("Web3Wallet", "Balances for ${chainId ?: "evm"} ($address): ${balances.size}")
+                val maskedAddress = "${address.take(6)}…${address.takeLast(4)}"
+                Log.d("Web3Wallet", "Balances for ${chainId ?: "evm"} ($maskedAddress): ${balances.size}")
                 balances
             } else {
                 Log.e("Web3Wallet", "Failed to fetch balances for ${chainId ?: "evm"}: ${response.code()}")
                 null
             }
+        }.onFailure {
+            if (it is CancellationException) throw it
         }.getOrElse {
             Log.e("Web3Wallet", "Error fetching balances for ${chainId ?: "evm"}", it)
             null

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connections/ConnectionsViewModel.kt
@@ -8,12 +8,21 @@ import androidx.lifecycle.viewModelScope
 import com.reown.sample.wallet.BuildConfig
 import com.reown.sample.wallet.blockchain.TokenBalance
 import com.reown.sample.wallet.blockchain.createBalanceApiService
+import com.reown.sample.wallet.blockchain.isSpam
+import com.reown.sample.wallet.blockchain.processBalances
 import com.reown.sample.wallet.domain.WalletKitDelegate
 import com.reown.sample.wallet.domain.account.ACCOUNTS_1_EIP155_ADDRESS
 import com.reown.sample.wallet.domain.account.ACCOUNTS_2_EIP155_ADDRESS
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
+import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
+import com.reown.sample.wallet.domain.account.SuiAccountDelegate
+import com.reown.sample.wallet.domain.account.TONAccountDelegate
+import com.reown.sample.wallet.domain.account.TronAccountDelegate
+import com.reown.sample.wallet.ui.routes.dialog_routes.transaction.Chain
 import com.reown.walletkit.client.WalletKit
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,31 +53,62 @@ class ConnectionsViewModel : ViewModel() {
 
     private val balanceApiService = createBalanceApiService()
 
+    // Non-EVM addresses (Solana/Sui/TON/Tron) derived once, keyed by CAIP-2
+    // namespace. Deriving them is crypto/FFI work that must not run per render or
+    // per refresh; the underlying keys only change on wallet import, which
+    // recreates this view model.
+    private val nonEvmAddresses: Map<String, String> = buildMap {
+        runCatching { SolanaAccountDelegate.getSolanaPubKeyForKeyPair() }.getOrNull()
+            ?.takeIf { it.isNotBlank() }?.let { put("solana", it) }
+        runCatching { SuiAccountDelegate.address }.getOrNull()
+            ?.takeIf { it.isNotBlank() }?.let { put("sui", it) }
+        runCatching { TONAccountDelegate.addressFriendly }.getOrNull()
+            ?.takeIf { it.isNotBlank() }?.let { put("ton", it) }
+        runCatching { TronAccountDelegate.address }.getOrNull()
+            ?.takeIf { it.isNotBlank() }?.let { put("tron", it) }
+    }
+
     init {
         fetchBalances()
     }
+
+    /** Address shown and copied for a balance row, by the token's CAIP-2 namespace. */
+    fun addressFor(chainId: String): String =
+        nonEvmAddresses[chainId.substringBefore(":")] ?: EthAccountDelegate.address
 
     fun fetchBalances() {
         viewModelScope.launch(Dispatchers.IO) {
             _isLoadingBalances.value = true
             try {
-                val address = EthAccountDelegate.address
-                Log.d("Web3Wallet", "Fetching balances for address: $address")
-                val response = balanceApiService.getBalance(
-                    address = address,
-                    projectId = BuildConfig.PROJECT_ID
-                )
-                Log.d("Web3Wallet", "Balance API response code: ${response.code()}")
-                if (response.isSuccessful) {
-                    val balances = response.body()?.balances ?: emptyList()
-                    Log.d("Web3Wallet", "All balances received: ${balances.size} items")
-                    balances.forEach { balance ->
-                        Log.d("Web3Wallet", "Balance: ${balance.symbol} on ${balance.chainId} = ${balance.quantity.numeric}")
-                    }
-                    _balances.value = balances.sortedByDescending { it.value }
-                } else {
-                    Log.e("Web3Wallet", "Failed to fetch balances: ${response.code()} - ${response.errorBody()?.string()}")
+                val evmAddress = EthAccountDelegate.address
+                // EVM with no chainId returns all EVM tokens; each non-EVM chain
+                // is fetched with its own address + chainId.
+                val nonEvmTargets = buildList {
+                    nonEvmAddresses["solana"]?.let { add(it to Chain.SOLANA.id) }
+                    nonEvmAddresses["sui"]?.let { add(it to Chain.SUI.id) }
+                    nonEvmAddresses["ton"]?.let { add(it to TONAccountDelegate.mainnet) }
+                    nonEvmAddresses["tron"]?.let { add(it to TronAccountDelegate.mainnet) }
                 }
+
+                val deferred = buildList {
+                    add(async { fetchChainBalances(evmAddress, null) })
+                    nonEvmTargets.forEach { (address, chainId) ->
+                        add(async { fetchChainBalances(address, chainId) })
+                    }
+                }
+                val results = deferred.awaitAll()
+
+                if (results.all { it == null }) {
+                    Log.e("Web3Wallet", "All balance fetches failed; keeping current balances")
+                    return@launch
+                }
+
+                val apiBalances = results.filterNotNull().flatten().filterNot { isSpam(it) }
+                val availableNativeChainIds = buildSet {
+                    add("eip155:1")
+                    nonEvmTargets.forEach { (_, chainId) -> add(chainId) }
+                }
+                _balances.value = processBalances(apiBalances, availableNativeChainIds)
             } catch (e: Exception) {
                 Log.e("Web3Wallet", "Error fetching balances", e)
             } finally {
@@ -76,6 +116,28 @@ class ConnectionsViewModel : ViewModel() {
             }
         }
     }
+
+    // Returns the balances for a single call, or null if the request failed (so
+    // one chain's failure doesn't drop the others).
+    private suspend fun fetchChainBalances(address: String, chainId: String?): List<TokenBalance>? =
+        runCatching {
+            val response = balanceApiService.getBalance(
+                address = address,
+                projectId = BuildConfig.PROJECT_ID,
+                chainId = chainId
+            )
+            if (response.isSuccessful) {
+                val balances = response.body()?.balances ?: emptyList()
+                Log.d("Web3Wallet", "Balances for ${chainId ?: "evm"} ($address): ${balances.size}")
+                balances
+            } else {
+                Log.e("Web3Wallet", "Failed to fetch balances for ${chainId ?: "evm"}: ${response.code()}")
+                null
+            }
+        }.getOrElse {
+            Log.e("Web3Wallet", "Error fetching balances for ${chainId ?: "evm"}", it)
+            null
+        }
 
     var currentConnectionId: Int? = null
         set(value) {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/wallets/WalletsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/wallets/WalletsRoute.kt
@@ -52,7 +52,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.reown.sample.wallet.R
 import com.reown.sample.wallet.blockchain.TokenBalance
-import com.reown.sample.wallet.domain.account.EthAccountDelegate
+import com.reown.sample.wallet.blockchain.formatTokenAmount
 import com.reown.sample.wallet.ui.common.getChainIcon
 import com.reown.sample.wallet.ui.common.getChainName
 import com.reown.sample.wallet.ui.routes.composable_routes.connections.ConnectionsViewModel
@@ -117,7 +117,7 @@ fun WalletsRoute(
                         }
                     }
                     items(filteredBalances) { balance ->
-                        WalletBalanceItem(balance)
+                        WalletBalanceItem(balance, connectionsViewModel.addressFor(balance.chainId))
                     }
                     item { Spacer(modifier = Modifier.height(spacing.spacing2)) }
                 }
@@ -135,12 +135,11 @@ fun WalletsRoute(
 }
 
 @Composable
-fun WalletBalanceItem(balance: TokenBalance) {
+fun WalletBalanceItem(balance: TokenBalance, address: String) {
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing
     val borderRadius = WCTheme.borderRadius
     val chainName = getChainName(balance.chainId)
-    val address = EthAccountDelegate.address
     val shortAddress = "${address.take(6)}...${address.takeLast(4)}"
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
@@ -219,7 +218,7 @@ fun WalletBalanceItem(balance: TokenBalance) {
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = "${balance.quantity.numeric} ${balance.symbol}",
+                text = "${formatTokenAmount(balance.quantity.numeric)} ${balance.symbol}",
                 style = WCTheme.typography.bodyLgRegular.copy(
                     color = colors.textPrimary
                 )


### PR DESCRIPTION
Fetches wallet-sample balances per supported chain — a single EVM call (no chainId) plus one call per non-EVM chain (Solana/SUI/TON/TRON) with its chainId, all run in parallel and resilient to individual failures. Each balance row now shows and copies its own chain-specific address, resolved by CAIP-2 namespace from addresses derived once at init. A zero-balance native row is always shown for ETH/SOL/SUI/TON/TRX so every chain's address stays visible even with no funds, and scam/airdrop tokens (URL/domain/bracket symbols or a blocklist) are filtered out. Token amounts are formatted to 2 decimals, extending precision for small values until the first non-zero decimal. The token filter chips are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)