### PR TITLE
fix(pos): surface API error message for 401 and other HTTP errors

### DIFF
--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/ApiClient.kt
@@ -21,7 +21,7 @@ internal class ApiClient(
     private val merchantId: String,
     private val eventTracker: EventTracker,
     private val errorTracker: ErrorTracker,
-    moshi: Moshi,
+    private val moshi: Moshi,
     baseHttpClient: OkHttpClient,
     baseUrl: String = BuildConfig.CORE_API_BASE_URL
 ) {
@@ -31,8 +31,6 @@ internal class ApiClient(
         private const val MAX_POLL_INTERVAL_MS = 30_000L
         private const val MAX_TRANSIENT_RETRIES = 3
     }
-
-    private val errorAdapter by lazy { moshi.adapter(ApiErrorWrapper::class.java) }
 
     private val payApi: PayApi by lazy {
         val httpClient = baseHttpClient.newBuilder()
@@ -249,25 +247,19 @@ internal class ApiClient(
 
     private fun <T> parseErrorResponse(response: Response<T>): ApiErrorDetails {
         val errorBody = response.errorBody()?.string()
-        return if (errorBody != null) {
-            try {
-                errorAdapter.fromJson(errorBody)?.error ?: ApiErrorDetails(
-                    code = "HTTP_${response.code()}",
-                    message = response.message()
-                )
-            } catch (e: Exception) {
-                errorTracker.trackError(PulseErrorType.PARSE_ERROR, e.message ?: "Failed to parse error response", "parseErrorResponse")
-                ApiErrorDetails(
-                    code = "HTTP_${response.code()}",
-                    message = response.message()
-                )
-            }
-        } else {
-            ApiErrorDetails(
-                code = "HTTP_${response.code()}",
-                message = response.message()
-            )
+
+        parseApiErrorBody(moshi, errorBody)?.let { return it }
+
+        // The body was absent or unparseable — track it (when there was something to parse)
+        // and fall back to the HTTP status line. The reason-phrase is empty under HTTP/2,
+        // so synthesize a message from the status code to avoid surfacing a blank error.
+        if (!errorBody.isNullOrBlank()) {
+            errorTracker.trackError(PulseErrorType.PARSE_ERROR, "Failed to parse error response: $errorBody", "parseErrorResponse")
         }
+        return ApiErrorDetails(
+            code = "HTTP_${response.code()}",
+            message = response.message().ifBlank { "HTTP ${response.code()} error" }
+        )
     }
 
     private fun isSdkError(code: String): Boolean {

--- a/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
+++ b/product/pos/src/main/kotlin/com/walletconnect/pos/api/Mapping.kt
@@ -1,6 +1,30 @@
 package com.walletconnect.pos.api
 
+import com.squareup.moshi.Moshi
 import com.walletconnect.pos.Pos
+
+/**
+ * Parses an HTTP error response body into [ApiErrorDetails].
+ *
+ * The API returns error bodies in one of two shapes:
+ *  - wrapped: `{"status":"error","error":{"code":"...","message":"..."}}`
+ *  - flat:    `{"code":"...","message":"..."}` (e.g. the 401 `invalid_api_key` response)
+ *
+ * Both are attempted. Returns `null` when the body is blank or matches neither shape,
+ * letting the caller fall back to the HTTP status line. This is important because the
+ * HTTP reason-phrase is empty under HTTP/2, so the body is the only source of a message.
+ */
+internal fun parseApiErrorBody(moshi: Moshi, errorBody: String?): ApiErrorDetails? {
+    if (errorBody.isNullOrBlank()) return null
+
+    runCatching { moshi.adapter(ApiErrorWrapper::class.java).fromJson(errorBody)?.error }
+        .getOrNull()?.let { return it }
+
+    runCatching { moshi.adapter(ApiErrorDetails::class.java).fromJson(errorBody) }
+        .getOrNull()?.let { if (it.message.isNotBlank()) return it }
+
+    return null
+}
 
 internal fun mapErrorCodeToPaymentError(code: String, message: String): Pos.PaymentEvent.PaymentError {
     return when (code) {

--- a/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
+++ b/product/pos/src/test/kotlin/com/walletconnect/pos/ApiClientTest.kt
@@ -1,22 +1,28 @@
 package com.walletconnect.pos
 
+import com.squareup.moshi.Moshi
+import com.walletconnect.pos.api.ApiErrorDetails
 import com.walletconnect.pos.api.ApiResult
 import com.walletconnect.pos.api.ErrorCodes
 import com.walletconnect.pos.api.GetPaymentStatusResponse
 import com.walletconnect.pos.api.PayApi
 import com.walletconnect.pos.api.PaymentStatus
+import com.walletconnect.pos.api.parseApiErrorBody
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
 import java.io.IOException
 
 class ApiClientTest {
+
+    private val moshi = Moshi.Builder().build()
 
     @Test
     fun `getPaymentStatus - returns success with requires_action status`() = runTest {
@@ -178,6 +184,69 @@ class ApiClientTest {
     }
 
     @Test
+    fun `getPaymentStatus - parses flat 401 error body without wrapper`() = runTest {
+        val mockApi = mockk<PayApi>()
+        // 401 invalid_api_key bodies are flat: {"code":"...","message":"..."} (no "error" wrapper)
+        val errorBody = """{"code":"invalid_api_key","message":"Invalid API key"}"""
+            .toResponseBody("application/json".toMediaType())
+
+        coEvery { mockApi.getPaymentStatus("pay_401") } returns Response.error(401, errorBody)
+
+        val result = callGetPaymentStatus(mockApi, "pay_401")
+
+        assertTrue(result is ApiResult.Error)
+        val error = result as ApiResult.Error
+        assertEquals("invalid_api_key", error.code)
+        assertEquals("Invalid API key", error.message)
+    }
+
+    @Test
+    fun `getPaymentStatus - synthesizes message when reason-phrase is empty under HTTP2`() = runTest {
+        val mockApi = mockk<PayApi>()
+        // Simulate a real HTTP/2 response: empty body AND empty reason-phrase.
+        val rawResponse = okhttp3.Response.Builder()
+            .code(401)
+            .message("") // HTTP/2 does not transmit a reason-phrase
+            .protocol(okhttp3.Protocol.HTTP_2)
+            .request(okhttp3.Request.Builder().url("https://api.pay.walletconnect.com/v1/payments").build())
+            .build()
+        val emptyBody = "".toResponseBody("application/json".toMediaType())
+
+        coEvery { mockApi.getPaymentStatus("pay_401") } returns Response.error(emptyBody, rawResponse)
+
+        val result = callGetPaymentStatus(mockApi, "pay_401")
+
+        assertTrue(result is ApiResult.Error)
+        val error = result as ApiResult.Error
+        assertEquals("HTTP_401", error.code)
+        assertTrue(error.message.isNotBlank())
+        assertEquals("HTTP 401 error", error.message)
+    }
+
+    @Test
+    fun `parseApiErrorBody - parses wrapped error envelope`() {
+        val body = """{"status":"error","error":{"code":"payment_not_found","message":"Payment not found"}}"""
+        val details = parseApiErrorBody(moshi, body)
+        assertEquals("payment_not_found", details?.code)
+        assertEquals("Payment not found", details?.message)
+    }
+
+    @Test
+    fun `parseApiErrorBody - parses flat error body`() {
+        val body = """{"code":"invalid_api_key","message":"Invalid API key"}"""
+        val details = parseApiErrorBody(moshi, body)
+        assertEquals("invalid_api_key", details?.code)
+        assertEquals("Invalid API key", details?.message)
+    }
+
+    @Test
+    fun `parseApiErrorBody - returns null for blank or unparseable body`() {
+        assertNull(parseApiErrorBody(moshi, null))
+        assertNull(parseApiErrorBody(moshi, ""))
+        assertNull(parseApiErrorBody(moshi, "not json"))
+    }
+
+    @Test
     fun `polling - terminates when isFinal is true`() = runTest {
         val mockApi = mockk<PayApi>()
         var callCount = 0
@@ -238,17 +307,15 @@ class ApiClientTest {
                     ApiResult.Success(data)
                 }
             } else {
+                // Mirror ApiClient.parseErrorResponse: parse the body, else fall back to the
+                // HTTP status line (synthesizing a message when the reason-phrase is blank).
                 val errorBody = response.errorBody()?.string()
-                if (errorBody != null && errorBody.contains("error")) {
-                    // Parse nested error structure: {"status":"error","error":{"code":"...","message":"..."}}
-                    val codeMatch = Regex(""""error"\s*:\s*\{[^}]*"code"\s*:\s*"([^"]+)"""").find(errorBody)
-                    val messageMatch = Regex(""""error"\s*:\s*\{[^}]*"message"\s*:\s*"([^"]+)"""").find(errorBody)
-                    val code = codeMatch?.groupValues?.get(1) ?: "HTTP_${response.code()}"
-                    val message = messageMatch?.groupValues?.get(1) ?: response.message()
-                    ApiResult.Error(code, message)
-                } else {
-                    ApiResult.Error("HTTP_${response.code()}", response.message())
-                }
+                val details = parseApiErrorBody(moshi, errorBody)
+                    ?: ApiErrorDetails(
+                        code = "HTTP_${response.code()}",
+                        message = response.message().ifBlank { "HTTP ${response.code()} error" }
+                    )
+                ApiResult.Error(details.code, details.message)
             }
         } catch (e: IOException) {
             ApiResult.Error(ErrorCodes.NETWORK_ERROR, e.message ?: "Network error")


### PR DESCRIPTION
## Problem

Reported in Slack: a **401 response surfaces no error message** in the SDK.

```
Response{protocol=h2, code=401, message=, url=https://api.pay.walletconnect.com/v1/payments}
```

The server *does* return a body — `{"code":"invalid_api_key","message":"Invalid API key"}` — the SDK just wasn't reading it.

## Root cause

`ApiClient.parseErrorResponse()` had two bugs:

1. **Only the wrapped error shape was parsed.** It deserialized into `ApiErrorWrapper` (`{"status":..,"error":{code,message}}`). The 401 body is **flat** (`{"code":..,"message":..}`, no `error` wrapper), so Moshi threw and it fell into the `catch`.
2. **The fallback used `response.message()`** — the HTTP reason-phrase, which is **empty under HTTP/2**. So the final `PaymentError.message` was `""`.

## Fix

```mermaid
flowchart TD
    A[HTTP error response] --> B[parseApiErrorBody]
    B --> C{wrapped<br/>error envelope?}
    C -- yes --> R[ApiErrorDetails]
    C -- no --> D{flat<br/>code/message?}
    D -- yes --> R
    D -- no / blank --> E[Fallback:<br/>HTTP_code + synthesized message]
    R --> F[PaymentError with real message]
    E --> F
```

- New pure, testable `parseApiErrorBody(moshi, body)` that tries **both** the wrapped and flat shapes.
- `parseErrorResponse` synthesizes a message from the status code when the reason-phrase is blank, so a blank error is never surfaced (`"HTTP 401 error"`).
- Removed a stray `println("kobe: ...")` debug line in the error path.

**Result:** a 401 now yields `PaymentError.CreatePaymentFailed("Invalid API key")` with `code = invalid_api_key`, instead of an empty message.

## Tests

`ApiClientTest` previously re-implemented error parsing with a **regex copy** — which is why this slipped through. It now exercises the **real** parser, with new cases for:
- the flat 401 body (`invalid_api_key`)
- the HTTP/2 empty-reason-phrase fallback (raw `Protocol.HTTP_2` response)
- direct `parseApiErrorBody` unit tests (wrapped / flat / blank / unparseable)

Full `:product:pos:testDebugUnitTest` suite is green.

## Not included (follow-up?)

The sample app's `ErrorScreen` shows hardcoded copy keyed on error code and never displays the SDK message; a 401 maps to the generic "create_failed" screen. Surfacing the real message and/or a dedicated auth-error path is a separate UX change — happy to do it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)