### PR TITLE
chore(pay): bump yttrium to 0.10.58 and drop removed ComplianceFailed error

### DIFF
--- a/.github/workflows/ci_e2e_tests.yml
+++ b/.github/workflows/ci_e2e_tests.yml
@@ -67,7 +67,10 @@ jobs:
         with:
           name: ${{ matrix.conf.name }}-apk
           path: sample/${{ matrix.conf.name }}/build/outputs/apk/internal/*.apk
-          retention-days: 1
+          # Keep a window large enough that re-running only the failed E2E job
+          # still finds the build artifacts. With retention-days: 1 a re-run a day
+          # later downloads 0 APKs and the job fails on `find apks`.
+          retention-days: 5
 
   run_e2e_tests:
     name: Run E2E Tests
@@ -100,6 +103,13 @@ jobs:
       - name: List APKs
         run: |
           echo "Available APKs:"
+          # Fail fast with an actionable message if the build artifacts are missing
+          # (e.g. re-running only this job after the APK artifacts have expired).
+          if [ ! -d apks ] || [ -z "$(find apks -name '*.apk' -print -quit)" ]; then
+            echo "ERROR: no APKs were downloaded. The *-apk artifacts likely expired."
+            echo "Re-run the whole workflow (not just this job) so the build jobs run again."
+            exit 1
+          fi
           find apks -name "*.apk" | xargs ls -la
 
       - name: Install Maestro

--- a/product/pay/README.md
+++ b/product/pay/README.md
@@ -473,7 +473,6 @@ sealed class GetPaymentOptionsError : Exception() {
     data class OptionNotFound(override val message: String)
     data class PaymentNotReady(override val message: String)
     data class InvalidAccount(override val message: String)
-    data class ComplianceFailed(override val message: String)
     data class Http(override val message: String)
     data class InternalError(override val message: String)
 }
@@ -535,9 +534,6 @@ result.onFailure { error ->
         }
         is Pay.GetPaymentOptionsError.InvalidAccount -> {
             showError("Invalid account address")
-        }
-        is Pay.GetPaymentOptionsError.ComplianceFailed -> {
-            showError("Compliance check failed")
         }
         is Pay.GetPaymentOptionsError.Http -> {
             showError("Network error: ${error.message}")

--- a/product/pay/build.gradle.kts
+++ b/product/pay/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
 //    implementation("com.github.reown-com:yttrium-wcpay:unspecified")
 
     //jitpack
-    implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.56") {
+    implementation("com.github.reown-com.yttrium:yttrium-wcpay:0.10.58") {
         exclude(group = "net.java.dev.jna", module = "jna")
     }
     implementation("net.java.dev.jna:jna:5.17.0@aar")

--- a/product/pay/src/main/java/com/walletconnect/pay/Mappers.kt
+++ b/product/pay/src/main/java/com/walletconnect/pay/Mappers.kt
@@ -171,9 +171,6 @@ internal object Mappers {
             is YttriumGetPaymentOptionsError.InvalidAccount ->
                 Pay.GetPaymentOptionsError.InvalidAccount(error.v1)
 
-            is YttriumGetPaymentOptionsError.ComplianceFailed ->
-                ComplianceFailed(error.v1)
-
             is YttriumGetPaymentOptionsError.Http ->
                 Pay.GetPaymentOptionsError.Http(error.v1)
 

--- a/product/pay/src/main/java/com/walletconnect/pay/Pay.kt
+++ b/product/pay/src/main/java/com/walletconnect/pay/Pay.kt
@@ -125,7 +125,6 @@ object Pay {
         data class OptionNotFound(override val message: String) : GetPaymentOptionsError()
         data class PaymentNotReady(override val message: String) : GetPaymentOptionsError()
         data class InvalidAccount(override val message: String) : GetPaymentOptionsError()
-        data class ComplianceFailed(override val message: String) : GetPaymentOptionsError()
         data class Http(override val message: String) : GetPaymentOptionsError()
         data class InternalError(override val message: String) : GetPaymentOptionsError()
     }

--- a/product/pay/src/test/kotlin/com/walletconnect/pay/PayErrorsTest.kt
+++ b/product/pay/src/test/kotlin/com/walletconnect/pay/PayErrorsTest.kt
@@ -87,13 +87,6 @@ class PayErrorsTest {
     }
 
     @Test
-    fun `GetPaymentOptionsError ComplianceFailed should hold correct message`() {
-        val error = Pay.GetPaymentOptionsError.ComplianceFailed("Compliance check failed")
-
-        assertEquals("Compliance check failed", error.message)
-    }
-
-    @Test
     fun `GetPaymentOptionsError Http should hold correct message`() {
         val error = Pay.GetPaymentOptionsError.Http("Server error 500")
 

--- a/sample/wallet/build.gradle.kts
+++ b/sample/wallet/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
 
     // local .m2 build
     //    implementation("com.github.reown-com:yttrium-utils:unspecified")
-    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.56") {
+    implementation("com.github.reown-com.yttrium:yttrium-utils:0.10.58") {
         exclude(group = "net.java.dev.jna", module = "jna")
     }
     implementation("net.java.dev.jna:jna:5.17.0@aar")


### PR DESCRIPTION
Bumps `yttrium-wcpay` (product/pay) and `yttrium-utils` (sample/wallet) from `0.10.56` to `0.10.58`. The new UniFFI bindings removed the `ComplianceFailed` subclass from `GetPaymentOptionsException`, which broke compilation of the error mapper. This PR removes the now-unreachable `ComplianceFailed` handling: the mapper branch in `Mappers.kt`, the public `Pay.GetPaymentOptionsError.ComplianceFailed` type, its unit test, and its documentation. The sanctioned case now flows through the remaining error branches. Note: removing the public `ComplianceFailed` type is a breaking API change for any external consumer doing an exhaustive `when` on `GetPaymentOptionsError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)