### PR TITLE
ci: run Pay E2E tests daily at 06:00 UTC

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -78,10 +78,10 @@ jobs:
           ./gradlew :sample:wallet:assembleInternal
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@52e0ab7755ca993bd829062278654ed12b2d471d
+        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - synchronize
       - edited
+  schedule:
+    - cron: '0 6 * * *' # Runs every day at 06:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Updates the Pay E2E Maestro workflow with two changes:

- Adds a `schedule` trigger so the tests run every 24 hours at 06:00 UTC, in addition to the existing PR and `workflow_dispatch` triggers.
- Bumps the `WalletConnect/actions/maestro/*` actions SHA to `3a145abaa0dcf9f609fabe17f6e6722e0db49535`.

Scheduled runs use the default branch (`develop`) and reuse the existing balance check and Slack failure notification (the `*Trigger:*` field will show `schedule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)