### PR TITLE
test(wallet/pay): add USDT-on-Polygon Permit2 E2E test wiring

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -141,8 +141,12 @@ jobs:
             sleep 5
 
             echo "Running Maestro Pay E2E tests:"
-            MAESTRO_EXIT=0
-            $HOME/.maestro/bin/maestro test --env APP_ID=com.reown.sample.wallet.internal --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC="${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }}" --env WPAY_MERCHANT_ID_SINGLE_NOKYC="${{ secrets.WPAY_MERCHANT_ID_SINGLE_NOKYC }}" --env WPAY_CUSTOMER_KEY_MULTI_NOKYC="${{ secrets.WPAY_CUSTOMER_KEY_MULTI_NOKYC }}" --env WPAY_MERCHANT_ID_MULTI_NOKYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_NOKYC }}" --env WPAY_CUSTOMER_KEY_MULTI_KYC="${{ secrets.WPAY_CUSTOMER_KEY_MULTI_KYC }}" --env WPAY_MERCHANT_ID_MULTI_KYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }}" --include-tags pay --test-output-dir debug-artifacts/maestro-output .maestro/ || MAESTRO_EXIT=$?
+            # android-emulator-runner runs each script line in its own `sh -c`, so a
+            # shell variable can't carry Maestro's exit code to the final `exit` line.
+            # Persist it to a file and re-exit with it, otherwise a flow failure is
+            # masked and the job goes green. (The `; echo $?` keeps this line itself
+            # exit-0 so the error-log extraction below still runs.)
+            $HOME/.maestro/bin/maestro test --env APP_ID=com.reown.sample.wallet.internal --env WPAY_CUSTOMER_KEY_SINGLE_NOKYC="${{ secrets.WPAY_CUSTOMER_KEY_SINGLE_NOKYC }}" --env WPAY_MERCHANT_ID_SINGLE_NOKYC="${{ secrets.WPAY_MERCHANT_ID_SINGLE_NOKYC }}" --env WPAY_CUSTOMER_KEY_MULTI_NOKYC="${{ secrets.WPAY_CUSTOMER_KEY_MULTI_NOKYC }}" --env WPAY_MERCHANT_ID_MULTI_NOKYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_NOKYC }}" --env WPAY_CUSTOMER_KEY_MULTI_KYC="${{ secrets.WPAY_CUSTOMER_KEY_MULTI_KYC }}" --env WPAY_MERCHANT_ID_MULTI_KYC="${{ secrets.WPAY_MERCHANT_ID_MULTI_KYC }}" --include-tags pay --test-output-dir debug-artifacts/maestro-output .maestro/ ; echo "$?" > debug-artifacts/maestro-exit-code
 
             # Extract error logs for easier debugging
             echo "Extracting error logs..."
@@ -151,7 +155,8 @@ jobs:
             # Stop logcat capture
             kill $LOGCAT_PID 2>/dev/null || true
 
-            exit $MAESTRO_EXIT
+            # Propagate Maestro's real exit code so the step fails when any flow failed.
+            exit "$(cat debug-artifacts/maestro-exit-code)"
 
       - name: Upload debug artifacts
         if: always()

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -77,8 +77,10 @@ jobs:
         run: |
           ./gradlew :sample:wallet:assembleInternal
 
+      # TEMP: pinned to the WalletConnect/actions PR #97 head (adds pay_usdt_polygon
+      # + the permit2-reset action). Re-pin to the squash-merge commit on master once #97 lands.
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
 
       - name: Install Maestro
         uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
@@ -167,6 +169,23 @@ jobs:
             debug-artifacts/full-logcat.txt
             debug-artifacts/emulator-errors.log
           if-no-files-found: warn
+
+      # Reset the USDT Permit2 allowance back to 0 so the next pay_usdt_polygon run
+      # re-exercises the approve step. Runs even when the suite failed (if: always())
+      # so a mid-flow failure doesn't leave the allowance set. Uses the shared
+      # permit2-reset action (the private key goes via env, never the CLI).
+      # continue-on-error so a reset hiccup can't fail an otherwise-green run.
+      # TEMP: pinned to WalletConnect/actions PR #97 head; re-pin with pay-tests once #97 lands.
+      - name: Reset USDT Permit2 allowance (Polygon)
+        if: always()
+        continue-on-error: true
+        uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
+        with:
+          chain-id: eip155:137
+          # polygon-rpc.com is gated (HTTP 401 "tenant disabled") in CI; use publicnode.
+          rpc-url: https://polygon-bor-rpc.publicnode.com
+          token-address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
+          private-key: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
 
       - name: Send Slack notification
         if: failure()

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -77,13 +77,11 @@ jobs:
         run: |
           ./gradlew :sample:wallet:assembleInternal
 
-      # TEMP: pinned to the WalletConnect/actions PR #97 head (adds pay_usdt_polygon
-      # + the permit2-reset action). Re-pin to the squash-merge commit on master once #97 lands.
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
+        uses: WalletConnect/actions/maestro/pay-tests@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@3a145abaa0dcf9f609fabe17f6e6722e0db49535
+        uses: WalletConnect/actions/maestro/setup@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -180,11 +178,10 @@ jobs:
       # so a mid-flow failure doesn't leave the allowance set. Uses the shared
       # permit2-reset action (the private key goes via env, never the CLI).
       # continue-on-error so a reset hiccup can't fail an otherwise-green run.
-      # TEMP: pinned to WalletConnect/actions PR #97 head; re-pin with pay-tests once #97 lands.
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@d07c1f8a83dde5c52b7c8649a6814f98ba716b6b
+        uses: WalletConnect/actions/maestro/permit2-reset@3fd66ca1de3848a089d8e3c628e6f54bfcfd999f
         with:
           chain-id: eip155:137
           # polygon-rpc.com is gated (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -12,6 +12,8 @@ env:
   BASE_RPC: 'https://mainnet.base.org'
   OP_USDC: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'
   OP_RPC: 'https://mainnet.optimism.io'
+  POLYGON_USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
+  POLYGON_RPC: 'https://polygon-bor-rpc.publicnode.com'
 
 jobs:
   check-balance:
@@ -112,3 +114,95 @@ jobs:
           env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
         run: |
           echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Optimism USDC alert"
+
+      # USDT on Polygon funds the pay_usdt_polygon Permit2 flow (the actual payment).
+      - name: Check USDT balance on Polygon
+        id: poly_usdt_balance
+        run: |
+          BALANCE=$(cast call --rpc-url "$POLYGON_RPC" "$POLYGON_USDT" \
+            "balanceOf(address)(uint256)" \
+            "${{ vars.TEST_WALLET_ADDRESS }}" | sed 's/\[.*\]//' | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+          echo "USDT on Polygon: $BALANCE_HUMAN ($BALANCE raw)"
+
+      - name: Prepare USDT on Polygon alert
+        id: poly_usdt_alert
+        run: |
+          BALANCE="${{ steps.poly_usdt_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.USDT_POLYGON_THRESHOLD_UNITS || '1000000' }}"
+          if [ "$BALANCE" -lt "$THRESHOLD" ]; then
+            BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT on Polygon in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }}"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (USDT on Polygon)
+        if: |
+          steps.poly_usdt_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.poly_usdt_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (USDT on Polygon - no webhook)
+        if: |
+          steps.poly_usdt_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Polygon USDT alert"
+
+      # Native POL gas on Polygon: needed for both the payment txs (approve + pay)
+      # and the post-test Permit2 allowance-reset tx.
+      - name: Check POL gas balance on Polygon
+        id: poly_pol_balance
+        run: |
+          BALANCE=$(cast balance --rpc-url "$POLYGON_RPC" "${{ vars.TEST_WALLET_ADDRESS }}" | tr -d '[:space:]')
+          echo "balance=$BALANCE" >> $GITHUB_OUTPUT
+          BALANCE_HUMAN=$(echo "scale=6; $BALANCE / 1000000000000000000" | bc)
+          echo "POL on Polygon: $BALANCE_HUMAN ($BALANCE wei)"
+
+      - name: Prepare Polygon POL gas alert
+        id: poly_pol_alert
+        run: |
+          BALANCE="${{ steps.poly_pol_balance.outputs.balance }}"
+          THRESHOLD="${{ vars.POLYGON_POL_THRESHOLD_WEI || '1000000000000000000' }}"
+          # Use bc for the comparison: wei values overflow shell arithmetic.
+          if [ "$(echo "$BALANCE < $THRESHOLD" | bc)" -eq 1 ]; then
+            BALANCE_HUMAN=$(echo "scale=6; $BALANCE / 1000000000000000000" | bc)
+            THRESHOLD_HUMAN=$(echo "scale=6; $THRESHOLD / 1000000000000000000" | bc)
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} POL (gas) on Polygon in wallet: \
+              ${{ vars.TEST_WALLET_ADDRESS }} (currently ${BALANCE_HUMAN})"
+            echo "should_alert=true" >> "$GITHUB_OUTPUT"
+            echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"
+            echo "::warning::$ALERT_TEXT"
+          fi
+
+      - name: Send Slack alert (Polygon POL gas)
+        if: |
+          steps.poly_pol_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ env.SLACK_FAUCETBOT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ steps.poly_pol_alert.outputs.text }}"
+            }
+
+      - name: Skip Slack alert (Polygon POL gas - no webhook)
+        if: |
+          steps.poly_pol_alert.outputs.should_alert == 'true' &&
+          env.SLACK_FAUCETBOT_WEBHOOK_URL == ''
+        run: |
+          echo "::warning::SLACK_FAUCETBOT_WEBHOOK_URL not configured, skipping Polygon POL gas alert"

--- a/.github/workflows/e2e_balance_check.yml
+++ b/.github/workflows/e2e_balance_check.yml
@@ -134,7 +134,7 @@ jobs:
           if [ "$BALANCE" -lt "$THRESHOLD" ]; then
             BALANCE_HUMAN=$(echo "scale=2; $BALANCE / 1000000" | bc)
             THRESHOLD_HUMAN=$(echo "scale=2; $THRESHOLD / 1000000" | bc)
-            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT on Polygon in wallet: \
+            ALERT_TEXT="[request] Can i have ${THRESHOLD_HUMAN} USDT0 on Polygon in wallet: \
               ${{ vars.TEST_WALLET_ADDRESS }}"
             echo "should_alert=true" >> "$GITHUB_OUTPUT"
             echo "text=$ALERT_TEXT" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,10 @@ maestro test --env APP_ID=com.reown.sample.wallet.debug .maestro/pay_single_opti
 
 **`ENABLE_TEST_MODE`:** This env var controls whether the manual URL input field is shown in the scanner screen. It defaults to `false` so the field is hidden in all builds (debug, internal, release). Only CI E2E builds and local test runs should set it to `true`.
 
+**USDT-on-Polygon Permit2 flow (`pay_usdt_polygon`):** USDT on Polygon is a plain ERC-20 (no EIP-3009/2612), so WC Pay uses the [Permit2](https://github.com/Uniswap/permit2) path — the wallet sends an `approve` (allowance) tx **and then** the payment tx. The flow best-effort observes the approve step via the `pay-loading-setup-note` testID, then asserts the success screen. It selects the option by its stable `pay-option-{assetSymbol}-{networkName}` testID (e.g. `pay-option-usdt-polygon`), which is additive to the order-dependent `pay-option-{index}`. (USDT on Arbitrum is EIP-3009 / signature-based and never needs an on-chain approve — Polygon is used precisely because it does.)
+
+After the suite, `ci_e2e_pay_tests.yml` calls the shared `WalletConnect/actions/maestro/permit2-reset` action to reset the USDT Permit2 allowance back to 0 so each run re-exercises `approve` (it signs a tx, so it's a Node step, not a Maestro `runScript`; the key goes via env, never the CLI). `e2e_balance_check.yml` also monitors USDT + POL (gas) on Polygon and pings the faucet bot on Slack when low. The test wallet must hold USDT **and** a little POL (gas) on Polygon.
+
 ### Code Quality
 
 ```bash

--- a/product/pay/src/androidTest/kotlin/com/walletconnect/pay/test/utils/Common.kt
+++ b/product/pay/src/androidTest/kotlin/com/walletconnect/pay/test/utils/Common.kt
@@ -12,15 +12,21 @@ internal object Common {
         InstrumentationRegistry.getArguments().getString("MERCHANT_API_KEY")
             ?: error("MERCHANT_API_KEY environment variable not set")
     }
-    const val TEST_ADDRESS = "0xEb52dc9cCE17f1F0Ab0606d846dce183B449033C"
     const val BASE_CHAIN = "eip155:8453"
     const val POLYGON_CHAIN = "eip155:137"
     const val PAY_API_BASE_URL = "https://api.pay.walletconnect.com/"
 
-    val testAccounts = listOf(
-        "$BASE_CHAIN:$TEST_ADDRESS",
-        "$POLYGON_CHAIN:$TEST_ADDRESS"
-    )
+    // The test wallet address is derived from TEST_WALLET_PRIVATE_KEY (via the signer),
+    // so it always matches whatever wallet that key points to — single source of truth,
+    // nothing to keep in sync. Accessed at test time, after TestClient has initialized.
+    val testAddress: String
+        get() = TestClient.signer.address
+
+    val testAccounts: List<String>
+        get() = listOf(
+            "$BASE_CHAIN:$testAddress",
+            "$POLYGON_CHAIN:$testAddress"
+        )
 }
 
 internal fun globalOnError(error: Throwable) {

--- a/product/pay/src/androidTest/kotlin/com/walletconnect/pay/test/utils/TestClient.kt
+++ b/product/pay/src/androidTest/kotlin/com/walletconnect/pay/test/utils/TestClient.kt
@@ -124,12 +124,9 @@ internal object TestClient {
 
             signer = TestWalletSigner(privateKey)
 
-            // Verify address matches expected
-            if (!signer.address.equals(Common.TEST_ADDRESS, ignoreCase = true)) {
-                throw IllegalStateException(
-                    "Signer address ${signer.address} does not match expected ${Common.TEST_ADDRESS}"
-                )
-            }
+            // The signer's address is derived from TEST_WALLET_PRIVATE_KEY and is the
+            // single source of truth for the test wallet (see Common.testAccounts), so
+            // there's no separate hardcoded address to drift out of sync.
             println("TestWalletSigner initialized with address: ${signer.address}")
         } catch (e: Exception) {
             val error = "Failed to initialize TestWalletSigner: ${e.message}"

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -330,9 +330,20 @@ private fun PaymentOptionsContent(
                 // `pay-option-$index`. Lets a test pick a specific asset+network when
                 // several options share a token symbol across networks.
                 val display = option.amount.display
-                val stableTag = "pay-option-" + listOfNotNull(display?.assetSymbol, display?.networkName)
-                    .joinToString("-")
-                    .lowercase()
+                // Build from asset+network when available; fall back to the option's
+                // unique id so the tag never collapses to a bare "pay-option-" (which
+                // would collide across rows with missing display data). Locale.ROOT
+                // keeps the tag identical regardless of device locale.
+                val stableTagParts = listOfNotNull(display?.assetSymbol, display?.networkName)
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                val stableTagSuffix = if (stableTagParts.isEmpty()) {
+                    option.id
+                } else {
+                    stableTagParts.joinToString("-")
+                }
+                val stableTag = "pay-option-" + stableTagSuffix
+                    .lowercase(Locale.ROOT)
                     .replace(Regex("\\s+"), "-")
                 Box(modifier = Modifier.testTag(stableTag)) {
                     PaymentOptionRow(

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -346,7 +347,7 @@ private fun PaymentOptionsContent(
                                     iconRes = R.drawable.ic_info,
                                     contentDescription = "Why info needed",
                                     onClick = onWhyInfoRequired,
-                                    modifier = Modifier.testTag("pay-info-required-badge")
+                                    modifier = Modifier.testTag("pay-option-info-required")
                                 )
                             }
                         } else null,
@@ -400,26 +401,35 @@ private fun PaymentOptionRow(
     val networkName = option.amount.display?.networkName?.lowercase() ?: "unknown"
     val requiresApproval = PaymentUtil.requiresApproval(option.actions)
 
-    val baseModifier = Modifier
+    val containerModifier = Modifier
         .fillMaxWidth()
         .height(72.dp)
         .clip(WCTheme.borderRadius.shapeLarge)
         .background(WCTheme.colors.foregroundPrimary)
-
-    val rowModifier = (if (onClick != null) baseModifier.clickable(onClick = onClick) else baseModifier)
-        .clearAndSetSemantics {
-            this.testTag = testTag
-            text = AnnotatedString(networkName)
-            if (onClick != null) role = Role.Button
-        }
         .padding(horizontal = WCTheme.spacing.spacing4)
 
     Row(
-        modifier = rowModifier,
+        modifier = containerModifier,
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        // Clickable main content. clearAndSetSemantics collapses this subtree into a single node
+        // (testTag + networkName text + Button role) so `copyTextFrom`/`tapOn` resolve cleanly.
+        // It is scoped to the main content only — a `trailing` marker keeps its own testTag and
+        // stays discoverable (e.g. the KYC `pay-option-info-required` badge).
+        val mainModifier = (if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .weight(1f)
+            .fillMaxHeight()
+            .clearAndSetSemantics {
+                this.testTag = testTag
+                text = AnnotatedString(networkName)
+                if (onClick != null) role = Role.Button
+            }
+
+        Row(
+            modifier = mainModifier,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             PaymentAssetIcon(
                 display = option.amount.display,
                 tokenIconSize = 32.dp,

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -324,23 +324,34 @@ private fun PaymentOptionsContent(
         ) {
             options.forEachIndexed { index, option ->
                 val hasCollectData = option.collectData?.url != null
-                PaymentOptionRow(
-                    option = option,
-                    feeEstimate = gasEstimates[option.id],
-                    isEstimatingFee = estimatingOptionIds.contains(option.id),
-                    onClick = { onOptionSelected(option.id) },
-                    testTag = "pay-option-$index",
-                    trailing = if (hasCollectData) {
-                        {
-                            BorderedIconButton(
-                                iconRes = R.drawable.ic_info,
-                                contentDescription = "Why info needed",
-                                onClick = onWhyInfoRequired,
-                                modifier = Modifier.testTag("pay-info-required-badge")
-                            )
-                        }
-                    } else null,
-                )
+                // Stable, network+token-keyed testTag for deterministic selection
+                // (e.g. `pay-option-usdt-polygon`), additive to the order-dependent
+                // `pay-option-$index`. Lets a test pick a specific asset+network when
+                // several options share a token symbol across networks.
+                val display = option.amount.display
+                val stableTag = "pay-option-" + listOfNotNull(display?.assetSymbol, display?.networkName)
+                    .joinToString("-")
+                    .lowercase()
+                    .replace(Regex("\\s+"), "-")
+                Box(modifier = Modifier.testTag(stableTag)) {
+                    PaymentOptionRow(
+                        option = option,
+                        feeEstimate = gasEstimates[option.id],
+                        isEstimatingFee = estimatingOptionIds.contains(option.id),
+                        onClick = { onOptionSelected(option.id) },
+                        testTag = "pay-option-$index",
+                        trailing = if (hasCollectData) {
+                            {
+                                BorderedIconButton(
+                                    iconRes = R.drawable.ic_info,
+                                    contentDescription = "Why info needed",
+                                    onClick = onWhyInfoRequired,
+                                    modifier = Modifier.testTag("pay-info-required-badge")
+                                )
+                            }
+                        } else null,
+                    )
+                }
             }
         }
 
@@ -970,6 +981,10 @@ private fun ProcessingContent(
                 text = it,
                 style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textSecondary),
                 textAlign = TextAlign.Center,
+                // Secondary line shown only while setting up a token for the first time
+                // (e.g. the USDT Permit2 approve step). Lets pay_usdt_polygon observe the
+                // approve step by id instead of matching a copy string.
+                modifier = Modifier.testTag("pay-loading-setup-note")
             )
         }
     }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -70,6 +70,16 @@ class PaymentViewModel : ViewModel() {
                 return
             }
 
+            // Non-payable statuses (e.g. re-scanning an already-completed payment). These come
+            // back with an empty options list; without handling them here they would fall through
+            // to the empty-options branch below and be mislabelled as INSUFFICIENT_FUNDS.
+            Wallet.Model.PaymentStatus.SUCCEEDED,
+            Wallet.Model.PaymentStatus.PROCESSING,
+            Wallet.Model.PaymentStatus.FAILED -> {
+                _uiState.value = PaymentUiState.Error("This payment has already been processed", PaymentErrorType.GENERIC)
+                return
+            }
+
             else -> Unit
         }
 


### PR DESCRIPTION
## What

Adds the **Kotlin wallet consumer side** of the USDT-on-Polygon (Permit2) Maestro pay test. The shared flow itself lives in **WalletConnect/actions#97** (`pay_usdt_polygon.yaml`, now merged); this PR wires the wallet and CI to run it. USDT on Polygon is a plain ERC-20 (no EIP-3009/2612), so WC Pay uses the Permit2 path — the wallet sends an `approve` tx then the payment tx, exercising the two-tx flow that USDT-on-Arbitrum (signature-based) never would.

## Changes

- **`PaymentRoute.kt`** — add `pay-loading-setup-note` testID to the processing "setup" note (lets the flow observe the Permit2 `approve` step by id), and add a stable `pay-option-{assetSymbol}-{networkName}` testID (e.g. `pay-option-usdt-polygon`) that is additive to the order-dependent `pay-option-{index}`. Falls back to `option.id` and uses `Locale.ROOT` so the tag never collapses or drifts by locale.
- **`ci_e2e_pay_tests.yml`** — pin `maestro/pay-tests`, `setup`, and `permit2-reset` to the merged WalletConnect/actions SHA `3fd66ca`, add a post-test `maestro/permit2-reset` step (`if: always()`, `continue-on-error`) so each run re-exercises `approve`, and propagate Maestro's real exit code so a failing flow fails the job.
- **`e2e_balance_check.yml`** — monitor USDT0 + POL (gas) on Polygon and Slack-alert when low. **`AGENTS.md`** — document the flow, testIDs, and reset.
- **`product/pay` integration tests** — derive the test wallet address from `TEST_WALLET_PRIVATE_KEY` (single source of truth) instead of a hardcoded `Common.TEST_ADDRESS`, so changing the test wallet no longer breaks `TestClient` init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)