### PR TITLE
ci(e2e-pay): fix launch smoke check split across shells

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -130,15 +130,14 @@ jobs:
             # Launch smoke check: fail fast if the APK is broken (e.g. dex missing the
             # Application class -> ClassNotFoundException on startup). Without this, a
             # bad build surfaces as every Maestro flow failing, which is hard to diagnose.
+            # NOTE: android-emulator-runner runs each script line in its own `sh -c`,
+            # so the check must be a single line - a multi-line `if/fi` block would be
+            # split across shells and fail with "end of file unexpected".
             echo "Smoke-checking app launch:"
             adb logcat -c
             adb shell monkey -p com.reown.sample.wallet.internal -c android.intent.category.LAUNCHER 1 || true
             sleep 8
-            if adb logcat -d | grep -qE "FATAL EXCEPTION|ClassNotFoundException|Unable to instantiate application"; then
-              echo "ERROR: App crashed on launch - APK is broken, not running Maestro."
-              adb logcat -d | grep -E "FATAL EXCEPTION|ClassNotFoundException|Unable to instantiate application|AndroidRuntime" | head -40
-              exit 1
-            fi
+            adb logcat -d | grep -qE "FATAL EXCEPTION|ClassNotFoundException|Unable to instantiate application" && { echo "ERROR: App crashed on launch - APK is broken, not running Maestro."; adb logcat -d | grep -E "FATAL EXCEPTION|ClassNotFoundException|Unable to instantiate application|AndroidRuntime" | head -40; exit 1; } || echo "App launched cleanly."
 
             # Force stop before Maestro tests
             adb shell am force-stop com.reown.sample.wallet.internal


### PR DESCRIPTION
## Context

Follow-up to #402. That PR fixed the real problem — the stale-cache incremental build produced an `internal` APK whose dex was missing `WalletKitApplication`, crashing every Maestro flow. The [latest run](https://github.com/reown-com/reown-kotlin/actions/runs/27683473455/job/81876487377?pr=401) confirms the fix worked: **no `ClassNotFoundException` on launch**, the app started cleanly.

## The remaining bug

The launch smoke check #402 added used a multi-line `if … then … fi`. But `reactivecircus/android-emulator-runner` runs **each script line in its own `sh -c`** (the same gotcha the existing exit-code comment in this workflow already warns about). The block was split across shells:

```
/usr/bin/sh -c if adb logcat -d | grep -qE "..."; then
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "fi")
##[error]The process '/usr/bin/sh' failed with exit code 2
```

So the step failed (exit 2) even though the app launched fine.

## Fix

Collapse the check into a single line so it runs in one shell:

```bash
adb logcat -d | grep -qE "FATAL EXCEPTION|ClassNotFoundException|Unable to instantiate application" \
  && { echo "ERROR: ..."; ...; exit 1; } || echo "App launched cleanly."
```

Verified both paths locally: clean launch → exit 0, crash markers present → exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)