### PR TITLE
chore(wallet-sample): apply UX writing guidelines to the Pay flow

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/CopyableItem.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/CopyableItem.kt
@@ -25,7 +25,7 @@ import com.reown.sample.wallet.R
 fun CopyableItem(
     key: String,
     value: String,
-    onCopy: (String) -> Unit,
+    onCopy: (value: String, label: String) -> Unit,
 ) {
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing
@@ -36,7 +36,7 @@ fun CopyableItem(
             .fillMaxWidth()
             .clip(RoundedCornerShape(borderRadius.radius3))
             .background(color = colors.foregroundSecondary)
-            .clickable { onCopy(value) }
+            .clickable { onCopy(value, key) }
             .padding(spacing.spacing3)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/import_wallet/ImportWalletRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/import_wallet/ImportWalletRoute.kt
@@ -57,7 +57,7 @@ fun ImportWalletRoute(navController: NavController, onImportSuccess: () -> Unit 
     LaunchedEffect(importResult) {
         when (val result = importResult) {
             is ImportResult.Success -> {
-                Toast.makeText(context, "${selectedChain.label} wallet imported: ${result.address.take(6)}...${result.address.takeLast(4)}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "${selectedChain.label} wallet added: ${result.address.take(6)}...${result.address.takeLast(4)}", Toast.LENGTH_SHORT).show()
                 onImportSuccess()
                 navController.popBackStack()
             }
@@ -108,7 +108,7 @@ fun ImportWalletRoute(navController: NavController, onImportSuccess: () -> Unit 
         Spacer(modifier = Modifier.height(spacing.spacing4))
 
         Text(
-            text = "Import Wallet",
+            text = "Import wallet",
             style = WCTheme.typography.h6Medium.copy(color = colors.textPrimary),
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/import_wallet/ImportWalletViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/import_wallet/ImportWalletViewModel.kt
@@ -35,10 +35,10 @@ import uniffi.yttrium_utils.suiDeriveKeypairFromMnemonic
 import kotlin.coroutines.resume
 
 internal enum class ImportWalletChain(val label: String, val placeholder: String) {
-    EVM("EVM", "Enter mnemonic phrase or private key (0x...)"),
-    TON("TON", "Enter secret key:public key (colon separated)"),
+    EVM("Ethereum", "Enter mnemonic phrase or private key (0x...)"),
+    TON("Ton", "Enter secret key:public key (colon separated)"),
     SOLANA("Solana", "Enter mnemonic phrase or base58 keypair"),
-    SUI("SUI", "Enter mnemonic phrase or keypair string"),
+    SUI("Sui", "Enter mnemonic phrase or keypair string"),
     TRON("Tron", "Enter mnemonic phrase or private key (64 hex)"),
     STACKS("Stacks", "Enter wallet string"),
 }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/scan_uri/ScanUriRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/scan_uri/ScanUriRoute.kt
@@ -114,7 +114,7 @@ fun ScanUriRoute(navController: NavController, sheetState: BottomSheetNavigatorS
                 }, onQrCodeScanFailure = {
                     //todo Add Snackbar with error as a route parameter callback: https://stackoverflow.com/questions/68909340/how-to-show-snackbar-with-a-button-onclick-in-jetpack-compose
                     navController.popBackStack()
-                    Toast.makeText(context, "QR Scan failed", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, "Couldn't read the QR code. Try again.", Toast.LENGTH_SHORT).show()
                 })
             )
             try {
@@ -169,7 +169,7 @@ fun ScanView(navController: NavController, hasCamPermission: Boolean, previewVie
                     painter = qrFocusPainter, contentDescription = null
                 )
                 Text(
-                    text = "Scan the code", style = TextStyle(
+                    text = "Scan a WalletConnect QR code", style = TextStyle(
                         color = Color(0xffffffff), textAlign = TextAlign.Center, fontSize = 20.sp, fontWeight = FontWeight.SemiBold
                     ),
                     modifier = Modifier

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/scanner_options/ScannerOptionsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/bottomsheet_routes/scanner_options/ScannerOptionsRoute.kt
@@ -94,7 +94,7 @@ fun ScannerOptionsRoute(
             onClick = {
                 val text = clipboardManager.getText()?.text?.trim()
                 if (text.isNullOrEmpty()) {
-                    Toast.makeText(context, "No URL found in clipboard", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, "No URL in your clipboard. Copy a payment URL, then try again.", Toast.LENGTH_LONG).show()
                 } else {
                     navController.popBackStack()
                     onPair(text)

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connected_apps/ConnectedAppsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/connected_apps/ConnectedAppsRoute.kt
@@ -3,6 +3,7 @@ package com.reown.sample.wallet.ui.routes.composable_routes.connected_apps
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +21,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.reown.sample.common.ui.theme.WCTheme
 import com.reown.sample.wallet.ui.common.AppConnectionRow
@@ -43,7 +47,9 @@ fun ConnectedAppsRoute(
         WalletHeader(navController)
 
         if (connections.isEmpty()) {
-            EmptyConnectedApps()
+            EmptyConnectedApps(
+                onScanQrCode = { navController.navigate(Route.ScannerOptions.path) }
+            )
         } else {
             val spacing = WCTheme.spacing
             LazyColumn(
@@ -102,12 +108,14 @@ internal fun getConnectionChainIds(connectionUI: ConnectionUI): List<String> {
 }
 
 @Composable
-private fun EmptyConnectedApps() {
+private fun EmptyConnectedApps(onScanQrCode: () -> Unit) {
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing
 
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = spacing.spacing6),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -119,10 +127,26 @@ private fun EmptyConnectedApps() {
         )
         Spacer(modifier = Modifier.height(spacing.spacing1))
         Text(
-            text = "Scan a WalletConnect QR code to get started.",
+            text = "Apps you connect will show up here. Scan a QR code to add your first one.",
             style = WCTheme.typography.bodyLgRegular.copy(
                 color = colors.textSecondary
-            )
+            ),
+            textAlign = TextAlign.Center
         )
+        Spacer(modifier = Modifier.height(spacing.spacing4))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .clip(WCTheme.borderRadius.shapeLarge)
+                .background(colors.bgAccentPrimary)
+                .clickable(onClick = onScanQrCode),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "Scan QR code",
+                style = WCTheme.typography.bodyLgRegular.copy(color = Color.White)
+            )
+        }
     }
 }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/secret_keys/SecretKeysRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/secret_keys/SecretKeysRoute.kt
@@ -52,9 +52,9 @@ fun SecretKeysRoute(navController: NavHostController) {
     val spacing = WCTheme.spacing
     val colors = WCTheme.colors
     val borderRadius = WCTheme.borderRadius
-    val onCopy: (String) -> Unit = { value ->
+    val onCopy: (value: String, label: String) -> Unit = { value, label ->
         clipboardManager.setText(AnnotatedString(value))
-        Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, "$label copied", Toast.LENGTH_SHORT).show()
     }
 
     val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
@@ -75,7 +75,7 @@ fun SecretKeysRoute(navController: NavHostController) {
                 )
             }
             Text(
-                text = "Secret Keys & Phrases",
+                text = "Secret keys & phrases",
                 style = WCTheme.typography.h6Medium.copy(color = colors.textPrimary)
             )
         }
@@ -105,7 +105,7 @@ fun SecretKeysRoute(navController: NavHostController) {
 
             item {
                 SecretSectionCard(
-                    title = "TON Account",
+                    title = "Ton Account",
                     items = listOf(
                         "Friendly address" to TONAccountDelegate.addressFriendly,
                         "Secret key" to TONAccountDelegate.secretKey,
@@ -140,7 +140,7 @@ fun SecretKeysRoute(navController: NavHostController) {
 
             item {
                 SecretSectionCard(
-                    title = "SUI Account",
+                    title = "Sui Account",
                     items = listOf(
                         "Address" to SuiAccountDelegate.address,
                         "Key pair" to SuiAccountDelegate.keypair,
@@ -169,7 +169,7 @@ fun SecretKeysRoute(navController: NavHostController) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun EvmSecretSection(onCopy: (String) -> Unit) {
+private fun EvmSecretSection(onCopy: (value: String, label: String) -> Unit) {
     val mnemonic = EthAccountDelegate.mnemonic
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing
@@ -184,7 +184,7 @@ private fun EvmSecretSection(onCopy: (String) -> Unit) {
         verticalArrangement = Arrangement.spacedBy(spacing.spacing3)
     ) {
         Text(
-            text = "EIP155 Account",
+            text = "Ethereum Account",
             style = WCTheme.typography.bodyMdMedium.copy(color = colors.textPrimary)
         )
 
@@ -226,7 +226,7 @@ private fun EvmSecretSection(onCopy: (String) -> Unit) {
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(borderRadius.radius3))
                     .background(color = colors.foregroundPrimary)
-                    .clickable { onCopy(mnemonic) }
+                    .clickable { onCopy(mnemonic, "Recovery phrase") }
                     .padding(spacing.spacing3),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
@@ -251,7 +251,7 @@ private fun EvmSecretSection(onCopy: (String) -> Unit) {
                     .padding(spacing.spacing3)
             ) {
                 Text(
-                    text = "Imported via private key - no recovery phrase",
+                    text = "Imported via private key. No recovery phrase.",
                     style = WCTheme.typography.bodySmRegular.copy(color = colors.textSecondary)
                 )
             }
@@ -266,7 +266,7 @@ private fun EvmSecretSection(onCopy: (String) -> Unit) {
 private fun SecretSectionCard(
     title: String,
     items: List<Pair<String, String>>,
-    onCopy: (String) -> Unit,
+    onCopy: (value: String, label: String) -> Unit,
 ) {
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/settings/SettingsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/settings/SettingsRoute.kt
@@ -63,14 +63,14 @@ fun SettingsRoute(navController: NavHostController) {
 
             item {
                 NavigationCard(
-                    title = "Secret Keys & Phrases",
+                    title = "Secret keys & phrases",
                     onClick = { navController.navigate(Route.SecretKeysAndPhrases.path) }
                 )
             }
 
             item {
                 NavigationCard(
-                    title = "Import Wallet",
+                    title = "Import wallet",
                     onClick = { navController.navigate(Route.ImportWallet.path) }
                 )
             }
@@ -80,9 +80,9 @@ fun SettingsRoute(navController: NavHostController) {
                     clientId = viewModel.clientId,
                     deviceToken = deviceToken,
                     appVersion = BuildConfig.VERSION_NAME,
-                    onCopy = { value ->
+                    onCopy = { value, label ->
                         clipboardManager.setText(AnnotatedString(value))
-                        Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, "$label copied", Toast.LENGTH_SHORT).show()
                     }
                 )
             }
@@ -120,7 +120,7 @@ private fun DeviceSectionCard(
     clientId: String,
     deviceToken: String,
     appVersion: String,
-    onCopy: (String) -> Unit,
+    onCopy: (value: String, label: String) -> Unit,
 ) {
     val colors = WCTheme.colors
     val spacing = WCTheme.spacing

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentContent.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentContent.kt
@@ -1,0 +1,129 @@
+package com.reown.sample.wallet.ui.routes.dialog_routes.payment
+
+/**
+ * Centralized presentation copy for the WalletConnect Pay flow result and
+ * loading screens.
+ *
+ * The view-model carries only semantic state (success/error, the classified
+ * [PaymentErrorType], the raw error message, the token being set up); the view
+ * derives every user-facing string from the two pure helpers below. Keeping the
+ * copy here — rather than scattered across [PaymentRoute] and [PaymentViewModel]
+ * — means the wording for an outcome lives in exactly one place.
+ */
+
+/** What the result screen's primary action does. */
+enum class ResultActionKind { CLOSE, SCAN_QR }
+
+/** Full presentation for a result (success or error) screen. */
+data class PaymentResultContent(
+    val title: String,
+    // Errors show a secondary description line; success shows the title only.
+    val description: String? = null,
+    val iconTestId: String,
+    val actionLabel: String,
+    val actionKind: ResultActionKind,
+)
+
+private const val SUCCESS_DEFAULT_TITLE = "Payment confirmed"
+private const val GENERIC_ERROR_DESCRIPTION =
+    "No funds were moved. Try again, or pay with a different asset from checkout."
+
+/**
+ * Resolves the full presentation for a result screen.
+ *
+ * @param isSuccess       Whether the payment succeeded.
+ * @param errorType       The classified error (ignored when [isSuccess]).
+ * @param successSummary  Dynamic success summary, e.g. "You've paid 5.00 USDT to Acme".
+ * @param rawErrorMessage Raw error message used as the generic-error fallback.
+ */
+fun getResultContent(
+    isSuccess: Boolean,
+    errorType: PaymentErrorType?,
+    successSummary: String? = null,
+    rawErrorMessage: String? = null,
+): PaymentResultContent {
+    if (isSuccess) {
+        return PaymentResultContent(
+            title = successSummary?.takeIf { it.isNotBlank() } ?: SUCCESS_DEFAULT_TITLE,
+            iconTestId = "pay-result-success-icon",
+            actionLabel = "Done",
+            actionKind = ResultActionKind.CLOSE,
+        )
+    }
+
+    return when (errorType ?: PaymentErrorType.GENERIC) {
+        PaymentErrorType.INSUFFICIENT_FUNDS -> PaymentResultContent(
+            title = "Not enough funds in your wallet",
+            description = "This wallet doesn't have enough funds on the supported networks. Add funds, or pay with a different asset.",
+            iconTestId = "pay-result-insufficient-funds-icon",
+            actionLabel = "Got it",
+            actionKind = ResultActionKind.CLOSE,
+        )
+
+        PaymentErrorType.EXPIRED -> PaymentResultContent(
+            title = "Payment request expired",
+            description = "Ask the merchant to create a new payment, then try again.",
+            iconTestId = "pay-result-expired-icon",
+            actionLabel = "Scan a new QR code",
+            actionKind = ResultActionKind.SCAN_QR,
+        )
+
+        PaymentErrorType.CANCELLED -> PaymentResultContent(
+            title = "Payment request cancelled",
+            description = "Ask the merchant to create a new payment, then try again.",
+            iconTestId = "pay-result-cancelled-icon",
+            actionLabel = "Scan a new QR code",
+            actionKind = ResultActionKind.SCAN_QR,
+        )
+
+        PaymentErrorType.NOT_FOUND -> PaymentResultContent(
+            title = "Payment request not found",
+            description = "This payment link isn't valid, or it's already been completed.",
+            iconTestId = "pay-result-error-icon",
+            actionLabel = "Close",
+            actionKind = ResultActionKind.CLOSE,
+        )
+
+        PaymentErrorType.GENERIC -> PaymentResultContent(
+            title = "Payment didn't go through",
+            description = rawErrorMessage?.takeIf { it.isNotBlank() } ?: GENERIC_ERROR_DESCRIPTION,
+            iconTestId = "pay-result-error-icon",
+            actionLabel = "Close",
+            actionKind = ResultActionKind.CLOSE,
+        )
+    }
+}
+
+/** Steps that render the loading screen. Token setup happens during [CONFIRMING]. */
+enum class LoadingStep { PREPARING, CONFIRMING }
+
+/** Full presentation for a loading screen. */
+data class PaymentLoadingContent(
+    val message: String,
+    // Secondary line shown only while setting up a token for the first time.
+    val note: String? = null,
+)
+
+/**
+ * Resolves the loading copy for a [step]. When [setupTokenSymbol] is non-null
+ * the wallet is performing a one-time token setup (e.g. the USDT Permit2
+ * approve), which takes precedence over the step default.
+ */
+fun getLoadingContent(
+    step: LoadingStep,
+    setupTokenSymbol: String? = null,
+): PaymentLoadingContent {
+    if (setupTokenSymbol != null) {
+        return PaymentLoadingContent(
+            message = "Setting up $setupTokenSymbol",
+            note = "This usually takes a few seconds. Future $setupTokenSymbol payments will skip this step.",
+        )
+    }
+
+    return PaymentLoadingContent(
+        message = when (step) {
+            LoadingStep.CONFIRMING -> "Confirming your payment…"
+            LoadingStep.PREPARING -> "Preparing your payment…"
+        },
+    )
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentRoute.kt
@@ -199,9 +199,10 @@ fun PaymentRoute(
                 )
             }
             is PaymentUiState.Processing -> {
+                val loading = getLoadingContent(state.step, state.setupTokenSymbol)
                 ProcessingContent(
-                    message = state.message,
-                    note = state.note,
+                    message = loading.message,
+                    note = loading.note,
                 )
             }
             is PaymentUiState.Success -> {
@@ -255,7 +256,7 @@ private fun LoadingContent() {
         WalletConnectLoader(size = 120.dp)
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
         Text(
-            text = "Preparing your payment...",
+            text = getLoadingContent(LoadingStep.PREPARING).message,
             style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary),
             textAlign = TextAlign.Center,
             modifier = Modifier.testTag("pay-loading-message")
@@ -312,7 +313,7 @@ private fun PaymentOptionsContent(
             Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
 
             Text(
-                text = "Select a token to pay with",
+                text = "Choose the asset you want to pay with",
                 style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary)
             )
         }
@@ -688,7 +689,7 @@ private fun SummaryContent(
 
         PrimaryActionButton(
             primaryText = "Pay ${payLabel.total}",
-            secondaryText = if (payLabel.includesGasFee) " (incl. gas fee)" else null,
+            secondaryText = if (payLabel.includesGasFee) " (includes network fee)" else null,
             onClick = onConfirm,
             modifier = Modifier.testTag("pay-button-pay")
         )
@@ -696,7 +697,7 @@ private fun SummaryContent(
         if (requiresApproval) {
             Spacer(modifier = Modifier.height(WCTheme.spacing.spacing3))
             Text(
-                text = "Why does ${(selectedOption.amount.display?.assetSymbol ?: "this token").uppercase(Locale.ROOT)} require a gas fee?",
+                text = "Why does ${(selectedOption.amount.display?.assetSymbol ?: "this token").uppercase(Locale.ROOT)} need a network fee?",
                 style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textSecondary),
                 textAlign = TextAlign.Center,
                 textDecoration = TextDecoration.Underline,
@@ -757,7 +758,7 @@ private fun GasFeeInfoContent(
             Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
 
             Text(
-                text = "Why does $tokenSymbol require a gas fee?",
+                text = "Why does $tokenSymbol need a network fee?",
                 style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary),
                 textAlign = TextAlign.Center
             )
@@ -765,7 +766,7 @@ private fun GasFeeInfoContent(
             Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
 
             Text(
-                text = "The gas fee covers a one-time setup that lets your wallet pay with $tokenSymbol.",
+                text = "The network fee covers a one-time setup so your wallet can pay with $tokenSymbol.",
                 style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textSecondary),
                 textAlign = TextAlign.Center
             )
@@ -797,7 +798,7 @@ private fun GasFeeInfoContent(
             )
             Spacer(modifier = Modifier.width(WCTheme.spacing.spacing2))
             Text(
-                text = "Gas fee: $gasText",
+                text = "Network fee: $gasText",
                 style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textSecondary)
             )
         }
@@ -805,7 +806,7 @@ private fun GasFeeInfoContent(
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing6))
 
         PrimaryActionButton(
-            text = "Got it!",
+            text = "Got it",
             onClick = onBack
         )
     }
@@ -842,21 +843,21 @@ private fun WhyInfoRequiredContent(
         Spacer(modifier = Modifier.height(28.dp))
 
         Text(
-            text = "Why do we collect personal details?",
+            text = "Why we collect personal details",
             style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary)
         )
 
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing4))
 
         Text(
-            text = "To meet compliance requirements, some basic information is collected from WalletConnect Pay users.\n\nThis is typically a one-time step\u2014if you use the same wallet on this network again, you won\u2019t need to provide the info again, unless your information changes.",
+            text = "We collect a few basic details to meet compliance requirements for WalletConnect Pay.\n\nWe only ask once per wallet on this network. You won\u2019t see this again unless your details change.",
             style = WCTheme.typography.bodyLgRegular.copy(color = WCTheme.colors.textSecondary)
         )
 
         Spacer(modifier = Modifier.height(28.dp))
 
         PrimaryActionButton(
-            text = "Got it!",
+            text = "Got it",
             onClick = onBack
         )
     }
@@ -1046,18 +1047,23 @@ private fun SuccessContent(
 
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing6))
 
-        // Success message with payment details
-        val displayAmount = paymentInfo?.let {
-            formatDisplayAmount(
+        // Success summary with payment details, falling back to the default title.
+        val successSummary = paymentInfo?.let {
+            val displayAmount = formatDisplayAmount(
                 value = it.amount.value,
                 decimals = it.amount.display?.decimals ?: 2,
                 symbol = it.amount.display?.assetSymbol ?: it.amount.unit
             )
-        } ?: ""
-        val merchantName = paymentInfo?.merchant?.name ?: "Merchant"
+            "You've paid $displayAmount to ${it.merchant.name}"
+        }
+        val content = getResultContent(
+            isSuccess = true,
+            errorType = null,
+            successSummary = successSummary,
+        )
 
         Text(
-            text = "You've paid $displayAmount to $merchantName",
+            text = content.title,
             style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary),
             textAlign = TextAlign.Center
         )
@@ -1065,7 +1071,7 @@ private fun SuccessContent(
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing8))
 
         PrimaryActionButton(
-            text = "Got it!",
+            text = content.actionLabel,
             onClick = onDone,
             modifier = Modifier.testTag("pay-button-result-action-success")
         )
@@ -1079,28 +1085,14 @@ private fun ErrorContent(
     onClose: () -> Unit,
     onScanNewQrCode: () -> Unit = {}
 ) {
-    val title = when (errorType) {
-        PaymentErrorType.INSUFFICIENT_FUNDS -> "Not enough funds"
-        PaymentErrorType.EXPIRED -> "Your payment has expired"
-        PaymentErrorType.CANCELLED -> "This payment was cancelled"
-        PaymentErrorType.NOT_FOUND -> "Payment not found"
-        PaymentErrorType.GENERIC -> "Transaction failed"
-    }
-
-    val subtitle = when (errorType) {
-        PaymentErrorType.INSUFFICIENT_FUNDS -> "This wallet doesn't have enough funds on the supported networks to complete the payment."
-        PaymentErrorType.EXPIRED -> "Please ask the merchant to generate a new payment and try again."
-        PaymentErrorType.CANCELLED -> "Please ask the merchant to generate a new payment and try again."
-        PaymentErrorType.NOT_FOUND -> "This payment link is no longer valid."
-        PaymentErrorType.GENERIC -> message.ifBlank { null }
-    }
-
-    val errorIconTag = when (errorType) {
-        PaymentErrorType.INSUFFICIENT_FUNDS -> "pay-result-insufficient-funds-icon"
-        PaymentErrorType.EXPIRED -> "pay-result-expired-icon"
-        PaymentErrorType.CANCELLED -> "pay-result-cancelled-icon"
-        PaymentErrorType.NOT_FOUND, PaymentErrorType.GENERIC -> "pay-result-error-icon"
-    }
+    val content = getResultContent(
+        isSuccess = false,
+        errorType = errorType,
+        rawErrorMessage = message,
+    )
+    val title = content.title
+    val subtitle = content.description
+    val errorIconTag = content.iconTestId
 
     val errorActionTag = when (errorType) {
         PaymentErrorType.INSUFFICIENT_FUNDS -> "pay-button-result-action-insufficient_funds"
@@ -1153,29 +1145,14 @@ private fun ErrorContent(
 
         Spacer(modifier = Modifier.height(WCTheme.spacing.spacing8))
 
-        when (errorType) {
-            PaymentErrorType.EXPIRED, PaymentErrorType.CANCELLED, PaymentErrorType.NOT_FOUND -> {
-                PrimaryActionButton(
-                    text = "Scan new QR code",
-                    onClick = onScanNewQrCode,
-                    modifier = Modifier.testTag(errorActionTag)
-                )
-            }
-            PaymentErrorType.INSUFFICIENT_FUNDS -> {
-                PrimaryActionButton(
-                    text = "Got it!",
-                    onClick = onClose,
-                    modifier = Modifier.testTag(errorActionTag)
-                )
-            }
-            else -> {
-                PrimaryActionButton(
-                    text = "Close",
-                    onClick = onClose,
-                    modifier = Modifier.testTag(errorActionTag)
-                )
-            }
-        }
+        PrimaryActionButton(
+            text = content.actionLabel,
+            onClick = when (content.actionKind) {
+                ResultActionKind.SCAN_QR -> onScanNewQrCode
+                ResultActionKind.CLOSE -> onClose
+            },
+            modifier = Modifier.testTag(errorActionTag)
+        )
     }
 }
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -352,12 +352,8 @@ class PaymentViewModel : ViewModel() {
         val showSetupLoader = PaymentUtil.shouldShowSetupLoader(option.actions)
 
         _uiState.value = PaymentUiState.Processing(
-            message = if (showSetupLoader) {
-                "Setting up $symbol"
-            } else {
-                "Processing your payment..."
-            },
-            note = if (showSetupLoader) "This usually takes a few seconds. Future $symbol payments will skip this step." else null,
+            step = LoadingStep.CONFIRMING,
+            setupTokenSymbol = if (showSetupLoader) symbol else null,
             paymentInfo = storedPaymentInfo,
         )
 
@@ -394,7 +390,7 @@ class PaymentViewModel : ViewModel() {
 
         if (!showSetupLoader) {
             _uiState.value = PaymentUiState.Processing(
-                message = "Processing your payment...",
+                step = LoadingStep.CONFIRMING,
                 paymentInfo = storedPaymentInfo,
             )
         }
@@ -405,8 +401,8 @@ class PaymentViewModel : ViewModel() {
                 when (action.action.method) {
                     ETH_SEND_TRANSACTION -> {
                         _uiState.value = PaymentUiState.Processing(
-                            message = "Setting up $symbol",
-                            note = "This usually takes a few seconds. Future $symbol payments will skip this step.",
+                            step = LoadingStep.CONFIRMING,
+                            setupTokenSymbol = symbol,
                             paymentInfo = storedPaymentInfo,
                         )
 
@@ -416,8 +412,10 @@ class PaymentViewModel : ViewModel() {
                         signatures.add(txHash)
 
                         if (showSetupLoader && action == approvalAction) {
+                            // Token setup done — drop the setup copy and fall back to the
+                            // generic confirming message while the payment finalizes.
                             _uiState.value = PaymentUiState.Processing(
-                                message = "Finalizing your payment...",
+                                step = LoadingStep.CONFIRMING,
                                 paymentInfo = storedPaymentInfo,
                             )
                         }
@@ -580,8 +578,8 @@ sealed class PaymentUiState {
     ) : PaymentUiState()
 
     data class Processing(
-        val message: String,
-        val note: String? = null,
+        val step: LoadingStep,
+        val setupTokenSymbol: String? = null,
         val paymentInfo: Wallet.Model.PaymentInfo? = null,
     ) : PaymentUiState()
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -445,7 +445,6 @@ class PaymentViewModel : ViewModel() {
                             Log.d("PaymentViewModel", "Payment SUCCEEDED")
                             PaymentTokenPreferenceStore.saveLastPaidTokenUnit(option.amount.unit)
                             _uiState.value = PaymentUiState.Success(
-                                message = "Payment completed successfully!",
                                 paymentInfo = storedPaymentInfo,
                                 resultInfo = response.info,
                             )
@@ -454,7 +453,6 @@ class PaymentViewModel : ViewModel() {
                         Wallet.Model.PaymentStatus.PROCESSING -> {
                             Log.d("PaymentViewModel", "Payment PROCESSING")
                             _uiState.value = PaymentUiState.Success(
-                                message = "Payment is being processed...",
                                 paymentInfo = storedPaymentInfo,
                                 resultInfo = response.info,
                             )
@@ -584,7 +582,6 @@ sealed class PaymentUiState {
     ) : PaymentUiState()
 
     data class Success(
-        val message: String,
         val paymentInfo: Wallet.Model.PaymentInfo? = null,
         val resultInfo: Wallet.Model.PaymentResultInfo? = null,
     ) : PaymentUiState()

--- a/sample/wallet/src/test/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentContentTest.kt
+++ b/sample/wallet/src/test/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentContentTest.kt
@@ -1,0 +1,124 @@
+package com.reown.sample.wallet.ui.routes.dialog_routes.payment
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaymentContentTest {
+
+    // ----- getResultContent: success -----
+
+    @Test
+    fun `success uses the dynamic summary as the title with a Done close action`() {
+        val content = getResultContent(
+            isSuccess = true,
+            errorType = null,
+            successSummary = "You've paid 5.00 USDT to Acme",
+        )
+
+        assertEquals("You've paid 5.00 USDT to Acme", content.title)
+        assertNull(content.description)
+        assertEquals("pay-result-success-icon", content.iconTestId)
+        assertEquals("Done", content.actionLabel)
+        assertEquals(ResultActionKind.CLOSE, content.actionKind)
+    }
+
+    @Test
+    fun `success falls back to the default title when no summary is given`() {
+        assertEquals("Payment confirmed", getResultContent(true, null).title)
+        assertEquals("Payment confirmed", getResultContent(true, null, successSummary = " ").title)
+    }
+
+    // ----- getResultContent: errors -----
+
+    @Test
+    fun `insufficient funds maps to its title, description, icon and close action`() {
+        val content = getResultContent(false, PaymentErrorType.INSUFFICIENT_FUNDS)
+
+        assertEquals("Not enough funds in your wallet", content.title)
+        assertTrue(content.description!!.contains("Add funds, or pay"))
+        assertEquals("pay-result-insufficient-funds-icon", content.iconTestId)
+        assertEquals("Got it", content.actionLabel)
+        assertEquals(ResultActionKind.CLOSE, content.actionKind)
+    }
+
+    @Test
+    fun `expired and cancelled route to the scan-QR action`() {
+        val expired = getResultContent(false, PaymentErrorType.EXPIRED)
+        assertEquals("Payment request expired", expired.title)
+        assertEquals("pay-result-expired-icon", expired.iconTestId)
+        assertEquals("Scan a new QR code", expired.actionLabel)
+        assertEquals(ResultActionKind.SCAN_QR, expired.actionKind)
+
+        val cancelled = getResultContent(false, PaymentErrorType.CANCELLED)
+        assertEquals("Payment request cancelled", cancelled.title)
+        assertEquals("pay-result-cancelled-icon", cancelled.iconTestId)
+        assertEquals("Scan a new QR code", cancelled.actionLabel)
+        assertEquals(ResultActionKind.SCAN_QR, cancelled.actionKind)
+    }
+
+    @Test
+    fun `not found maps to its title, description and close action`() {
+        val content = getResultContent(false, PaymentErrorType.NOT_FOUND)
+
+        assertEquals("Payment request not found", content.title)
+        assertTrue(content.description!!.contains("isn't valid"))
+        assertEquals("pay-result-error-icon", content.iconTestId)
+        assertEquals("Close", content.actionLabel)
+        assertEquals(ResultActionKind.CLOSE, content.actionKind)
+    }
+
+    @Test
+    fun `generic uses the raw error message as the description, then a default`() {
+        assertEquals(
+            "boom",
+            getResultContent(false, PaymentErrorType.GENERIC, rawErrorMessage = "boom").description,
+        )
+        assertTrue(
+            getResultContent(false, PaymentErrorType.GENERIC).description!!.contains("No funds were moved"),
+        )
+    }
+
+    @Test
+    fun `an error with no classified type is treated as generic`() {
+        val content = getResultContent(false, errorType = null)
+
+        assertEquals("Payment didn't go through", content.title)
+        assertEquals("pay-result-error-icon", content.iconTestId)
+        assertEquals(ResultActionKind.CLOSE, content.actionKind)
+    }
+
+    // ----- getLoadingContent -----
+
+    @Test
+    fun `loading returns the step default with no note when nothing is being set up`() {
+        assertEquals(
+            PaymentLoadingContent("Preparing your payment…"),
+            getLoadingContent(LoadingStep.PREPARING),
+        )
+        assertEquals(
+            PaymentLoadingContent("Confirming your payment…"),
+            getLoadingContent(LoadingStep.CONFIRMING),
+        )
+    }
+
+    @Test
+    fun `loading returns the token-setup message and note when a token is being set up`() {
+        assertEquals(
+            PaymentLoadingContent(
+                message = "Setting up USDT",
+                note = "This usually takes a few seconds. Future USDT payments will skip this step.",
+            ),
+            getLoadingContent(LoadingStep.CONFIRMING, setupTokenSymbol = "USDT"),
+        )
+    }
+
+    @Test
+    fun `the setup token takes precedence over the step default`() {
+        assertEquals(
+            "Setting up USDC",
+            getLoadingContent(LoadingStep.PREPARING, setupTokenSymbol = "USDC").message,
+        )
+    }
+}


### PR DESCRIPTION
Ports [reown-com/react-native-examples#512](https://github.com/reown-com/react-native-examples/pull/512) (UX writing guidelines copy audit) and [#525](https://github.com/reown-com/react-native-examples/pull/525) (centralize Pay-flow result/loading copy) to the Kotlin wallet sample. Adds `PaymentContent.kt` with pure `getResultContent`/`getLoadingContent` helpers so the Pay result + loading copy lives in one place, with `PaymentUiState.Processing` now carrying semantic state and the view presentation-only (covered by a new `PaymentContentTest`). Applies the network-fee renames, error titles that state whether funds moved + a next step, `…` ellipsis, and sentence-case/next-step rewrites across the token selection, gas-fee and info modals plus connections, scanner, settings, secret keys and import. Two intentional behavioral changes from #525: the NOT_FOUND result button is now **Close** (was "Scan new QR code"), and the post-approval "Finalizing your payment…" step folds into "Confirming your payment…". All `pay-*` testIDs are preserved so the Maestro E2E flows keep matching; `:sample:wallet:assembleDebug` and the unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)