### PR TITLE
feat: add theme and themeVariables prop to IC form url

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeManager.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeManager.kt
@@ -2,6 +2,7 @@ package com.reown.sample.wallet.domain
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.Configuration
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -16,12 +17,28 @@ private const val THEME_MODE_KEY = "theme_mode"
  */
 object ThemeManager {
     private lateinit var sharedPrefs: SharedPreferences
+    private lateinit var appContext: Context
     private val _themeMode = MutableStateFlow(-1)
     val themeMode = _themeMode.asStateFlow()
 
     fun init(context: Context) {
+        appContext = context.applicationContext
         sharedPrefs = context.getSharedPreferences(THEME_PREFS, Context.MODE_PRIVATE)
         _themeMode.value = sharedPrefs.getInt(THEME_MODE_KEY, -1)
+    }
+
+    /**
+     * Resolves the effective dark/light state, mirroring [WalletKitActivity]:
+     * an explicit user preference (0/1) wins, otherwise we follow the system.
+     */
+    fun isDarkTheme(): Boolean = when (_themeMode.value) {
+        0 -> false
+        1 -> true
+        else -> {
+            val uiMode = appContext.resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK
+            uiMode == Configuration.UI_MODE_NIGHT_YES
+        }
     }
 
     fun setDarkMode(enabled: Boolean) {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeManager.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeManager.kt
@@ -35,6 +35,7 @@ object ThemeManager {
         0 -> false
         1 -> true
         else -> {
+            if (!::appContext.isInitialized) return false // safe default before init()
             val uiMode = appContext.resources.configuration.uiMode and
                 Configuration.UI_MODE_NIGHT_MASK
             uiMode == Configuration.UI_MODE_NIGHT_YES

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.reown.sample.wallet.domain.ThemeManager
 import com.reown.sample.wallet.domain.WalletKitDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
@@ -285,12 +286,12 @@ class PaymentViewModel : ViewModel() {
     }
 
     private fun buildUrlWithPrefill(baseUrl: String, schema: String?): String {
-        val prefill = buildPrefillParam(schema) ?: return baseUrl
-        val uri = Uri.parse(baseUrl)
-        return uri.buildUpon()
-            .appendQueryParameter("prefill", prefill)
-            .build()
-            .toString()
+        val theme = if (ThemeManager.isDarkTheme()) "dark" else "light"
+        val builder = Uri.parse(baseUrl).buildUpon()
+            .appendQueryParameter("theme", theme)
+            .appendQueryParameter("themeVariables", THEME_VARIABLES)
+        buildPrefillParam(schema)?.let { builder.appendQueryParameter("prefill", it) }
+        return builder.build().toString()
     }
 
     private fun buildPrefillParam(schema: String?): String? {
@@ -536,6 +537,10 @@ class PaymentViewModel : ViewModel() {
     private companion object {
         private const val PAY_EXPIRY_GUARD_MS = 10_000L
         private const val ETH_SEND_TRANSACTION = "eth_sendTransaction"
+
+        // base64url of {"fontFamily":"dm-sans","inputRadius":8,"buttonRadius":8}
+        private const val THEME_VARIABLES =
+            "eyJmb250RmFtaWx5IjoiZG0tc2FucyIsImlucHV0UmFkaXVzIjo4LCJidXR0b25SYWRpdXMiOjh9"
     }
 }
 


### PR DESCRIPTION
This pull request updates the `PaymentViewModel` to enhance theme support when building payment URLs. The changes ensure that theme information and specific theme variables are included as query parameters, improving the appearance and consistency of payment dialogs based on the user's theme preference.

**Enhancements to Payment URL construction:**

* The `buildUrlWithPrefill` method now adds `theme` (either `"dark"` or `"light"`) and `themeVariables` (a base64url-encoded JSON with font and radius settings) as query parameters to the payment URL. The `prefill` parameter is still included if available.
* Introduced a new constant, `THEME_VARIABLES`, containing the base64url-encoded theme variables.
* Added an import for `ThemeManager` to determine the current theme.