### PR TITLE
ci(e2e-pay): move scheduled run to 05:00 UTC

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
       - edited
   schedule:
-    - cron: '0 6 * * *' # Runs every day at 06:00 UTC
+    - cron: '0 5 * * *' # Runs every day at 05:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Moves the scheduled Pay E2E (Maestro) test run one hour earlier, from 06:00 UTC to 05:00 UTC, in `ci_e2e_pay_tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)