### PR TITLE
fix(foundation-test): assert real Relay behaviour for empty packageName

### DIFF
--- a/foundation/src/test/kotlin/com/reown/foundation/RelayTest.kt
+++ b/foundation/src/test/kotlin/com/reown/foundation/RelayTest.kt
@@ -51,14 +51,25 @@ class RelayTest {
 
     @ExperimentalTime
     @Test
-    fun `Connect with empty packageName when some packageName is already configured in Cloud - successful connection`() {
+    fun `Connect with empty packageName when some packageName is already configured in Cloud - connection rejected`() {
+        // Relay rejects an empty packageName query param with 403 (the empty value resolves to an empty
+        // origin instead of None, which then fails Cerberus validation). This test asserts that rejection.
         val testState = MutableStateFlow<TestState>(TestState.Idle)
         val (clientA: RelayInterface, clientB: RelayInterface) = initTwoClients(packageName = "")
 
-        //Await connection
-        val connectionTime = measureTime { awaitConnection(clientA, clientB) }.inWholeMilliseconds
-        println("Connection time: $connectionTime ms")
-        testState.compareAndSet(expect = TestState.Idle, update = TestState.Success)
+        clientA.eventsFlow.onEach { event ->
+            when (event) {
+                is Relay.Model.Event.OnConnectionFailed -> testState.compareAndSet(expect = TestState.Idle, update = TestState.Success)
+                else -> {}
+            }
+        }.launchIn(testScope)
+
+        clientB.eventsFlow.onEach { event ->
+            when (event) {
+                is Relay.Model.Event.OnConnectionFailed -> testState.compareAndSet(expect = TestState.Idle, update = TestState.Success)
+                else -> {}
+            }
+        }.launchIn(testScope)
 
         //Lock until is finished or timed out
         runBlocking {
@@ -68,11 +79,11 @@ class RelayTest {
                 delay(10)
             }
 
-            // Success or fail or idle
+            // Success (connection was rejected as expected) or fail or idle
             when (testState.value) {
                 is TestState.Success -> return@runBlocking
                 is TestState.Error -> fail((testState.value as TestState.Error).message)
-                is TestState.Idle -> fail("Test timeout")
+                is TestState.Idle -> fail("Test timeout - expected connection to be rejected")
             }
         }
     }

--- a/foundation/src/test/kotlin/com/reown/foundation/RelayTest.kt
+++ b/foundation/src/test/kotlin/com/reown/foundation/RelayTest.kt
@@ -388,11 +388,11 @@ class RelayTest {
 
         //Lock until is finished or timed out
         val start = System.currentTimeMillis()
-        while (!areBothReady.value && !didTimeout(start, 10000L)) {
+        while (!areBothReady.value && !didTimeout(start, 50000L)) {
             delay(10)
         }
 
-        if (didTimeout(start, 50000L)) {
+        if (!areBothReady.value) {
             throw Exception("Unable to establish socket connection")
         }
 


### PR DESCRIPTION
## Background

While investigating the Kotlin Relay validator, Mario noticed that the test `Connect with empty packageName ... - successful connection` passed even though Relay should reject empty `packageName` with 403. This PR confirms his analysis and fixes both the broken assertion helper and the test premise.

## Bug 1 — `awaitConnection` never failed

`RelayTest.awaitConnection` (`foundation/src/test/kotlin/com/reown/foundation/RelayTest.kt`):

```kotlin
val start = System.currentTimeMillis()
while (!areBothReady.value && !didTimeout(start, 10000L)) { delay(10) }
if (didTimeout(start, 50000L)) { throw Exception("Unable to establish socket connection") }
```

with `didTimeout(start, t) = currentTimeMillis() - start > t`.

The loop exits after at most **10s**, but the failure check requires **>50s** elapsed. The two statements are adjacent and synchronous, so elapsed time at the `if` is always ~10s — the `50000L` branch is **unreachable dead code**. `awaitConnection` returned normally whether or not the sockets opened, and the test then unconditionally marked success. A false positive that would pass even against a Relay 403-ing every request.

**Fix:** gate the throw on `!areBothReady.value` (fires the moment the loop gives up) and align the loop timeout to 50s.

## Bug 2 — wrong test premise

With `awaitConnection` fixed, the empty-packageName test correctly went red: Relay returns **`403 Forbidden`** for an empty `packageName` query param (the empty value resolves to an empty origin instead of `None`, failing Cerberus validation). Note production never sends an empty `packageName` — it is always `application.packageName` (`CoreProtocol.kt:141`); the empty case exists only in this test.

**Fix:** invert the test to assert the rejection (listen for `OnConnectionFailed`), matching the existing failure-test pattern, so CI reflects the real Relay contract.

## Open question for Relay

Is rejecting an empty `packageName` with 403 the intended Relay behaviour, or should an empty value be treated as `None` (no origin)? Following up with Mario — the test will be adjusted if the Relay contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)