### PR TITLE
feat(wallet-sample): add Pay form customization settings screen

### DIFF
--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/WalletKitApplication.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/WalletKitApplication.kt
@@ -20,6 +20,7 @@ import com.reown.notify.client.NotifyClient
 import com.reown.sample.wallet.domain.StacksAccountDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.domain.ThemeManager
+import com.reown.sample.wallet.domain.ThemeVariablesStore
 import com.reown.sample.wallet.domain.account.SmartAccountEnabler
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
 import com.reown.sample.wallet.domain.account.TONAccountDelegate
@@ -67,6 +68,7 @@ class WalletKitApplication : Application() {
 
         SmartAccountEnabler.init(this)
         ThemeManager.init(this)
+        ThemeVariablesStore.init(this)
 
         // Note: WalletConnectPay is now initialized automatically by WalletKit
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeVariablesStore.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeVariablesStore.kt
@@ -1,0 +1,43 @@
+package com.reown.sample.wallet.domain
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private const val THEME_VARIABLES_PREFS = "theme_variables_prefs"
+private const val THEME_VARIABLES_KEY = "theme_variables"
+private val THEME_VARIABLES_PREFIX = Regex("^themeVariables=", RegexOption.IGNORE_CASE)
+
+/**
+ * Persists the user-supplied `themeVariables` base64url string used to style the
+ * WalletConnect Pay data-collection webview. Empty when unset (no custom theme).
+ */
+object ThemeVariablesStore {
+    private lateinit var sharedPrefs: SharedPreferences
+    private val _themeVariables = MutableStateFlow("")
+    val themeVariables = _themeVariables.asStateFlow()
+
+    fun init(context: Context) {
+        sharedPrefs = context.getSharedPreferences(THEME_VARIABLES_PREFS, Context.MODE_PRIVATE)
+        _themeVariables.value = sharedPrefs.getString(THEME_VARIABLES_KEY, "").orEmpty()
+    }
+
+    fun save(input: String) {
+        val value = parseInput(input)
+        _themeVariables.value = value
+        sharedPrefs.edit().putString(THEME_VARIABLES_KEY, value).apply()
+    }
+
+    fun clear() {
+        _themeVariables.value = ""
+        sharedPrefs.edit().putString(THEME_VARIABLES_KEY, "").apply()
+    }
+
+    /**
+     * Accepts either a raw base64url value or the dashboard export form
+     * `themeVariables=<base64url>`, returning the bare base64url string.
+     */
+    fun parseInput(raw: String): String =
+        raw.trim().replaceFirst(THEME_VARIABLES_PREFIX, "")
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeVariablesStore.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/domain/ThemeVariablesStore.kt
@@ -14,24 +14,25 @@ private val THEME_VARIABLES_PREFIX = Regex("^themeVariables=", RegexOption.IGNOR
  * WalletConnect Pay data-collection webview. Empty when unset (no custom theme).
  */
 object ThemeVariablesStore {
-    private lateinit var sharedPrefs: SharedPreferences
+    private var sharedPrefs: SharedPreferences? = null
     private val _themeVariables = MutableStateFlow("")
     val themeVariables = _themeVariables.asStateFlow()
 
     fun init(context: Context) {
-        sharedPrefs = context.getSharedPreferences(THEME_VARIABLES_PREFS, Context.MODE_PRIVATE)
-        _themeVariables.value = sharedPrefs.getString(THEME_VARIABLES_KEY, "").orEmpty()
+        val prefs = context.getSharedPreferences(THEME_VARIABLES_PREFS, Context.MODE_PRIVATE)
+        sharedPrefs = prefs
+        _themeVariables.value = prefs.getString(THEME_VARIABLES_KEY, "").orEmpty()
     }
 
     fun save(input: String) {
         val value = parseInput(input)
         _themeVariables.value = value
-        sharedPrefs.edit().putString(THEME_VARIABLES_KEY, value).apply()
+        sharedPrefs?.edit()?.putString(THEME_VARIABLES_KEY, value)?.apply()
     }
 
     fun clear() {
         _themeVariables.value = ""
-        sharedPrefs.edit().putString(THEME_VARIABLES_KEY, "").apply()
+        sharedPrefs?.edit()?.putString(THEME_VARIABLES_KEY, "")?.apply()
     }
 
     /**

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/Web3WalletNavGraph.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/Web3WalletNavGraph.kt
@@ -26,6 +26,7 @@ import com.reown.sample.wallet.ui.routes.composable_routes.connection_details.Co
 import com.reown.sample.wallet.ui.routes.composable_routes.connections.ConnectionsViewModel
 import com.reown.sample.wallet.ui.routes.composable_routes.secret_keys.SecretKeysRoute
 import com.reown.sample.wallet.ui.routes.composable_routes.settings.SettingsRoute
+import com.reown.sample.wallet.ui.routes.composable_routes.theme_variables.ThemeVariablesRoute
 import com.reown.sample.wallet.ui.routes.composable_routes.wallets.WalletsRoute
 import com.reown.sample.wallet.ui.routes.bottomsheet_routes.scanner_options.ScannerOptionsRoute
 import com.reown.sample.wallet.ui.routes.dialog_routes.session_authenticate.SessionAuthenticateRoute
@@ -91,6 +92,9 @@ fun Web3WalletNavGraph(
         }
         composable(Route.SecretKeysAndPhrases.path) {
             SecretKeysRoute(navController)
+        }
+        composable(Route.ThemeVariables.path) {
+            ThemeVariablesRoute(navController)
         }
         bottomSheet(Route.ImportWallet.path) {
             ImportWalletRoute(

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/Route.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/Route.kt
@@ -20,6 +20,7 @@ sealed class Route(val path: String) {
     data object PaymentResult : Route("payment_result")
     data object SecretKeysAndPhrases : Route("secret_keys_and_phrases")
     data object ImportWallet : Route("import_wallet")
+    data object ThemeVariables : Route("theme_variables")
 }
 
 fun NavController.showSnackbar(message: String) {

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/settings/SettingsRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/settings/SettingsRoute.kt
@@ -76,6 +76,13 @@ fun SettingsRoute(navController: NavHostController) {
             }
 
             item {
+                NavigationCard(
+                    title = "Pay form customization",
+                    onClick = { navController.navigate(Route.ThemeVariables.path) }
+                )
+            }
+
+            item {
                 DeviceSectionCard(
                     clientId = viewModel.clientId,
                     deviceToken = deviceToken,

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
@@ -1,0 +1,218 @@
+@file:JvmSynthetic
+
+package com.reown.sample.wallet.ui.routes.composable_routes.theme_variables
+
+import android.util.Base64
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.navigation.NavHostController
+import com.reown.sample.common.ui.theme.WCTheme
+import com.reown.sample.wallet.R
+import com.reown.sample.wallet.domain.ThemeVariablesStore
+import org.json.JSONObject
+
+@Composable
+fun ThemeVariablesRoute(navController: NavHostController) {
+    val context = LocalContext.current
+    val colors = WCTheme.colors
+    val spacing = WCTheme.spacing
+    val borderRadius = WCTheme.borderRadius
+
+    var input by remember { mutableStateOf(ThemeVariablesStore.themeVariables.value) }
+    val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
+            .imePadding()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = statusBarTop)
+                .padding(horizontal = spacing.spacing1, vertical = spacing.spacing2),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_chevron_left),
+                    contentDescription = "Back",
+                    tint = colors.iconDefault
+                )
+            }
+            Text(
+                text = "Pay form customization",
+                style = WCTheme.typography.h6Medium.copy(color = colors.textPrimary)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = spacing.spacing3),
+            verticalArrangement = Arrangement.spacedBy(spacing.spacing3)
+        ) {
+            Text(
+                text = "Paste the themeVariables value exported from the dashboard. Both " +
+                    "\"themeVariables=<base64url>\" and the raw base64url value are accepted.",
+                style = WCTheme.typography.bodyMdRegular.copy(color = colors.textSecondary)
+            )
+
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                placeholder = {
+                    Text(
+                        text = "themeVariables=eyJ...",
+                        style = WCTheme.typography.bodyMdRegular.copy(color = colors.textSecondary)
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(spacing.spacing2 * 15),
+                textStyle = WCTheme.typography.bodyMdRegular.copy(color = colors.textPrimary),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    backgroundColor = colors.foregroundPrimary,
+                    focusedBorderColor = colors.borderAccentPrimary,
+                    unfocusedBorderColor = colors.borderPrimary,
+                    cursorColor = colors.iconAccentPrimary
+                ),
+                shape = RoundedCornerShape(borderRadius.radius3),
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+                maxLines = 6,
+            )
+
+            DecodedPreview(input = input)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.spacing2)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(spacing.spacing11)
+                        .clip(RoundedCornerShape(borderRadius.radius4))
+                        .background(colors.bgPrimary)
+                        .border(
+                            width = spacing.spacing05,
+                            color = colors.borderSecondary,
+                            shape = RoundedCornerShape(borderRadius.radius4)
+                        )
+                        .clickable {
+                            ThemeVariablesStore.clear()
+                            input = ""
+                            Toast.makeText(context, "Theme variables cleared", Toast.LENGTH_SHORT).show()
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Clear",
+                        style = WCTheme.typography.bodyLgRegular.copy(color = colors.textPrimary)
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(spacing.spacing11)
+                        .clip(RoundedCornerShape(borderRadius.radius4))
+                        .background(colors.bgAccentPrimary)
+                        .clickable {
+                            ThemeVariablesStore.save(input)
+                            Toast.makeText(context, "Theme variables saved", Toast.LENGTH_SHORT).show()
+                            navController.popBackStack()
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Save",
+                        style = WCTheme.typography.bodyLgRegular.copy(color = colors.textInvert)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(spacing.spacing3))
+        }
+    }
+}
+
+@Composable
+private fun DecodedPreview(input: String) {
+    val colors = WCTheme.colors
+    val spacing = WCTheme.spacing
+    val borderRadius = WCTheme.borderRadius
+
+    val decoded = remember(input) { decodeThemeVariables(input) }
+    if (decoded == null && input.isBlank()) return
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(borderRadius.radius4))
+            .background(colors.foregroundSecondary)
+            .padding(spacing.spacing4),
+        verticalArrangement = Arrangement.spacedBy(spacing.spacing2)
+    ) {
+        Text(
+            text = "Decoded",
+            style = WCTheme.typography.bodyMdMedium.copy(color = colors.textPrimary)
+        )
+        Text(
+            text = decoded ?: "Invalid themeVariables",
+            style = WCTheme.typography.bodyMdRegular.copy(
+                color = if (decoded != null) colors.textPrimary else colors.textSecondary
+            )
+        )
+    }
+}
+
+private fun decodeThemeVariables(input: String): String? = try {
+    val value = ThemeVariablesStore.parseInput(input)
+    if (value.isBlank()) {
+        null
+    } else {
+        val bytes = Base64.decode(value, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        JSONObject(String(bytes)).toString(2)
+    }
+} catch (e: Exception) {
+    null
+}

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -109,7 +110,7 @@ fun ThemeVariablesRoute(navController: NavHostController) {
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(spacing.spacing2 * 15),
+                    .heightIn(min = spacing.spacing13),
                 textStyle = WCTheme.typography.bodyMdRegular.copy(color = colors.textPrimary),
                 colors = TextFieldDefaults.outlinedTextFieldColors(
                     backgroundColor = colors.foregroundPrimary,

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/composable_routes/theme_variables/ThemeVariablesRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -38,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -126,52 +128,71 @@ fun ThemeVariablesRoute(navController: NavHostController) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing.spacing2)
             ) {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(spacing.spacing11)
-                        .clip(RoundedCornerShape(borderRadius.radius4))
-                        .background(colors.bgPrimary)
-                        .border(
-                            width = spacing.spacing05,
-                            color = colors.borderSecondary,
-                            shape = RoundedCornerShape(borderRadius.radius4)
-                        )
-                        .clickable {
-                            ThemeVariablesStore.clear()
-                            input = ""
-                            Toast.makeText(context, "Theme variables cleared", Toast.LENGTH_SHORT).show()
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "Clear",
-                        style = WCTheme.typography.bodyLgRegular.copy(color = colors.textPrimary)
-                    )
-                }
-
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(spacing.spacing11)
-                        .clip(RoundedCornerShape(borderRadius.radius4))
-                        .background(colors.bgAccentPrimary)
-                        .clickable {
-                            ThemeVariablesStore.save(input)
-                            Toast.makeText(context, "Theme variables saved", Toast.LENGTH_SHORT).show()
-                            navController.popBackStack()
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "Save",
-                        style = WCTheme.typography.bodyLgRegular.copy(color = colors.textInvert)
-                    )
-                }
+                ActionButton(
+                    text = "Clear",
+                    textColor = colors.textPrimary,
+                    backgroundColor = colors.bgPrimary,
+                    bordered = true,
+                    onClick = {
+                        ThemeVariablesStore.clear()
+                        input = ""
+                        Toast.makeText(context, "Theme variables cleared", Toast.LENGTH_SHORT).show()
+                    }
+                )
+                ActionButton(
+                    text = "Save",
+                    textColor = colors.textInvert,
+                    backgroundColor = colors.bgAccentPrimary,
+                    bordered = false,
+                    onClick = {
+                        ThemeVariablesStore.save(input)
+                        Toast.makeText(context, "Theme variables saved", Toast.LENGTH_SHORT).show()
+                        navController.popBackStack()
+                    }
+                )
             }
 
             Spacer(modifier = Modifier.height(spacing.spacing3))
         }
+    }
+}
+
+@Composable
+private fun RowScope.ActionButton(
+    text: String,
+    textColor: Color,
+    backgroundColor: Color,
+    bordered: Boolean,
+    onClick: () -> Unit,
+) {
+    val colors = WCTheme.colors
+    val spacing = WCTheme.spacing
+    val borderRadius = WCTheme.borderRadius
+
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .height(spacing.spacing11)
+            .clip(RoundedCornerShape(borderRadius.radius4))
+            .background(backgroundColor)
+            .then(
+                if (bordered) {
+                    Modifier.border(
+                        width = spacing.spacing05,
+                        color = colors.borderSecondary,
+                        shape = RoundedCornerShape(borderRadius.radius4)
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = WCTheme.typography.bodyLgRegular.copy(color = textColor)
+        )
     }
 }
 
@@ -205,14 +226,18 @@ private fun DecodedPreview(input: String) {
     }
 }
 
-private fun decodeThemeVariables(input: String): String? = try {
+private fun decodeThemeVariables(input: String): String? {
     val value = ThemeVariablesStore.parseInput(input)
-    if (value.isBlank()) {
-        null
-    } else {
-        val bytes = Base64.decode(value, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-        JSONObject(String(bytes)).toString(2)
+    if (value.isBlank()) return null
+    // Try URL-safe base64 first (the dashboard export format), then fall back to
+    // standard base64. Decode bytes as UTF-8 explicitly to stay device-independent.
+    val flags = listOf(
+        Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        Base64.DEFAULT
+    )
+    return flags.firstNotNullOfOrNull { flag ->
+        runCatching {
+            JSONObject(String(Base64.decode(value, flag), Charsets.UTF_8)).toString(2)
+        }.getOrNull()
     }
-} catch (e: Exception) {
-    null
 }

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/dialog_routes/payment/PaymentViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.reown.sample.wallet.domain.ThemeManager
+import com.reown.sample.wallet.domain.ThemeVariablesStore
 import com.reown.sample.wallet.domain.WalletKitDelegate
 import com.reown.sample.wallet.domain.account.EthAccountDelegate
 import com.reown.sample.wallet.domain.account.SolanaAccountDelegate
@@ -289,7 +290,9 @@ class PaymentViewModel : ViewModel() {
         val theme = if (ThemeManager.isDarkTheme()) "dark" else "light"
         val builder = Uri.parse(baseUrl).buildUpon()
             .appendQueryParameter("theme", theme)
-            .appendQueryParameter("themeVariables", THEME_VARIABLES)
+        ThemeVariablesStore.themeVariables.value
+            .takeIf { it.isNotBlank() }
+            ?.let { builder.appendQueryParameter("themeVariables", it) }
         buildPrefillParam(schema)?.let { builder.appendQueryParameter("prefill", it) }
         return builder.build().toString()
     }
@@ -537,10 +540,6 @@ class PaymentViewModel : ViewModel() {
     private companion object {
         private const val PAY_EXPIRY_GUARD_MS = 10_000L
         private const val ETH_SEND_TRANSACTION = "eth_sendTransaction"
-
-        // base64url of {"fontFamily":"dm-sans","inputRadius":8,"buttonRadius":8}
-        private const val THEME_VARIABLES =
-            "eyJmb250RmFtaWx5IjoiZG0tc2FucyIsImlucHV0UmFkaXVzIjo4LCJidXR0b25SYWRpdXMiOjh9"
     }
 }
 

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/host/WalletSampleHost.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/routes/host/WalletSampleHost.kt
@@ -87,7 +87,8 @@ fun WalletSampleHost(
     DisposableEffect(navController) {
         val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
             val route = destination.route ?: ""
-            val shouldHideBottomBar = route.startsWith(Route.SnackbarMessage.path)
+            val shouldHideBottomBar = route.startsWith(Route.SnackbarMessage.path) ||
+                route.startsWith(Route.ThemeVariables.path)
             bottomBarState.value = bottomBarState.value.copy(isDisplayed = !shouldHideBottomBar)
             shouldDimBackground = !route.startsWith(Route.SnackbarMessage.path)
         }


### PR DESCRIPTION
Replaces the hardcoded Pay data-collection webview `themeVariables` constant with a user-configurable **Settings → Pay form customization** screen, so themes exported from the dashboard can be tested without rebuilding.

The screen accepts either the raw base64url value or the `themeVariables=<base64url>` export form (prefix stripped), persists it in a new `ThemeVariablesStore`, and shows a live decoded-JSON preview. `PaymentViewModel` now reads the stored value and only appends the `themeVariables` query param when one is set (no built-in default). The route hides the bottom tabs so the keyboard doesn't push them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)