### PR TITLE
ci(e2e-pay): skip E2E on draft PRs; keep draft & off-default manual runs out of KPIs

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - edited
+      - ready_for_review # so E2E fires immediately when a draft is marked ready
   schedule:
     - cron: '0 5 * * *' # Runs every day at 05:00 UTC
   workflow_dispatch:

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,8 +1,10 @@
 name: E2E Pay Tests with Maestro
-# The " (Draft)" suffix is consumed by the E2E KPI metrics job (WalletConnect/actions)
-# to exclude draft-PR runs from the dashboard. Draft runs get a custom title; every
-# other run falls back to GitHub's default title (empty run-name). Don't change/remove it.
-run-name: ${{ github.event.pull_request.draft && format('{0} (Draft)', github.event.pull_request.title) || '' }}
+# "(skip-metrics)" in the run-name is consumed by the E2E KPI metrics job
+# (WalletConnect/actions) to drop a run from the dashboard. We stamp it on runs that
+# shouldn't count: draft PRs, and manual (workflow_dispatch) runs off the default
+# branch ('develop'). Every other run leaves run-name empty and keeps GitHub's
+# default title. Don't change/remove the marker.
+run-name: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && format('{0} (skip-metrics)', github.event.pull_request.title || github.ref_name) || '' }}
 
 on:
   pull_request:

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,4 +1,8 @@
 name: E2E Pay Tests with Maestro
+# The " (Draft)" suffix is consumed by the E2E KPI metrics job (WalletConnect/actions)
+# to exclude draft-PR runs from the dashboard. Draft runs get a custom title; every
+# other run falls back to GitHub's default title (empty run-name). Don't change/remove it.
+run-name: ${{ github.event.pull_request.draft && format('{0} (Draft)', github.event.pull_request.title) || '' }}
 
 on:
   pull_request:
@@ -20,7 +24,9 @@ jobs:
 
   build_and_run_pay_e2e_tests:
     needs: check-balance
-    if: always()
+    # Skip on draft PRs (still runnable manually via workflow_dispatch). The
+    # event guard keeps schedule/dispatch runs unaffected.
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: Build & Run Pay E2E Tests
     timeout-minutes: 45
     runs-on: ubuntu-16core

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -22,6 +22,9 @@ permissions:
 
 jobs:
   check-balance:
+    # Skip on draft PRs (matches the E2E job) so a draft run has all jobs
+    # skipped -> run conclusion "skipped", never counted toward KPIs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/e2e_balance_check.yml
     secrets: inherit
 

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -1,9 +1,5 @@
 name: E2E Pay Tests with Maestro
-# "(skip-metrics)" in the run-name is consumed by the E2E KPI metrics job
-# (WalletConnect/actions) to drop a run from the dashboard. We stamp it on runs that
-# shouldn't count: draft PRs, and manual (workflow_dispatch) runs off the default
-# branch ('develop'). Every other run leaves run-name empty and keeps GitHub's
-# default title. Don't change/remove the marker.
+# "(skip-metrics)" tells the E2E KPI job (WalletConnect/actions) to drop this run.
 run-name: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.draft) || (github.event_name == 'workflow_dispatch' && github.ref_name != 'develop')) && format('{0} (skip-metrics)', github.event.pull_request.title || github.ref_name) || '' }}
 
 on:
@@ -12,7 +8,7 @@ on:
       - opened
       - synchronize
       - edited
-      - ready_for_review # so E2E fires immediately when a draft is marked ready
+      - ready_for_review
   schedule:
     - cron: '0 5 * * *' # Runs every day at 05:00 UTC
   workflow_dispatch:
@@ -22,16 +18,12 @@ permissions:
 
 jobs:
   check-balance:
-    # Skip on draft PRs (matches the E2E job) so a draft run has all jobs
-    # skipped -> run conclusion "skipped", never counted toward KPIs.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/e2e_balance_check.yml
     secrets: inherit
 
   build_and_run_pay_e2e_tests:
     needs: check-balance
-    # Skip on draft PRs (still runnable manually via workflow_dispatch). The
-    # event guard keeps schedule/dispatch runs unaffected.
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     name: Build & Run Pay E2E Tests
     timeout-minutes: 45


### PR DESCRIPTION
## Why

Draft PRs run the full Maestro Pay E2E on every push — expensive WIP CI. And because this repo is **PR-trigger only** in the E2E KPI dashboard (no branch filter), both draft-PR runs **and** ad-hoc manual (`workflow_dispatch`) runs on feature branches land in **pass / flake / p95**. A hung E2E job on a draft PR recently pushed a platform’s **P95 PR feedback to 62m** vs the usual ~30m.

## Changes

1. **Skip E2E on draft PRs.** Both the E2E job **and** `check-balance` are draft-guarded, so a draft run has *every* job skipped → run conclusion `skipped`, never counted toward KPIs (independent of the marker below). Run manually via **Run workflow** when you want signal on a draft.
2. **Trigger on `ready_for_review`** so E2E fires the moment a draft is marked ready (not just on the next push).
3. **`(skip-metrics)` marker in `run-name`** — stamped on runs that shouldn’t count toward KPIs: **draft PRs**, and **manual runs off the default branch (`develop`)**. The metrics job (WalletConnect/actions) drops any run whose title carries it. Manual runs still execute; they just don’t skew the KPIs. Non-marked runs leave `run-name` empty and keep GitHub’s default title.

## Dependency

Metrics-side filter that consumes the marker: **WalletConnect/actions#107** (draft). Until it merges, this PR still stops draft PRs from running E2E; the marker is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)