### PR TITLE
ci: pin WalletConnect/actions to latest SHA (d385e7a)

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -83,10 +83,10 @@ jobs:
           ./gradlew clean :sample:wallet:assembleInternal --no-build-cache
 
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@ab2551783866d32b3668c1c69ee7678b39532f15
+        uses: WalletConnect/actions/maestro/pay-tests@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@ab2551783866d32b3668c1c69ee7678b39532f15
+        uses: WalletConnect/actions/maestro/setup@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -198,7 +198,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@ab2551783866d32b3668c1c69ee7678b39532f15
+        uses: WalletConnect/actions/maestro/permit2-reset@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
         with:
           chain-id: eip155:137
           # polygon-rpc.com is gated (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Review
-        uses: WalletConnect/actions/claude/auto-review@master
+        uses: WalletConnect/actions/claude/auto-review@d385e7a80fb4a3d378ee685021f3f7e24ccdf291
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           project_context: |

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Downloads shared WalletConnect Pay Maestro test flows from WalletConnect/actions repo.
 # Usage: ./scripts/setup-maestro-pay-tests.sh [ref]
-#   ref: actions repo branch/tag/commit to pull from (default: master)
+#   ref: actions repo branch/tag/commit to pull from (default: d385e7a80fb4a3d378ee685021f3f7e24ccdf291)
 
 set -euo pipefail
 
-REF="${1:-master}"
+REF="${1:-d385e7a80fb4a3d378ee685021f3f7e24ccdf291}"
 REPO="WalletConnect/actions"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
Pin all `WalletConnect/actions` references to the latest merged SHA `d385e7a80fb4a3d378ee685021f3f7e24ccdf291`.

## Changes
- `.github/workflows/ci_e2e_pay_tests.yml` — `maestro/pay-tests`, `maestro/setup`, `maestro/permit2-reset`
- `.github/workflows/claude-review.yml` — `claude/auto-review` (was `@master`)
- `scripts/setup-maestro-pay-tests.sh` — default `REF` (was `master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)