### PR TITLE
ci(maestro): drop universal-link (deeplink) support from wallet E2E

### DIFF
--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -82,13 +82,13 @@ jobs:
           # produce an inconsistent incremental APK whose dex is missing classes.
           ./gradlew clean :sample:wallet:assembleInternal --no-build-cache
 
-      # Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
-      # / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer copied.
+      # Pinned to WalletConnect/actions #109 merge (4be7c01 = removal of the Universal
+      # Link / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer copied.
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/pay-tests@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/setup@4be7c0112f9651fc63b18c137650b75d2fc9b200
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -200,7 +200,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
+        uses: WalletConnect/actions/maestro/permit2-reset@4be7c0112f9651fc63b18c137650b75d2fc9b200
         with:
           chain-id: eip155:137
           # polygon-rpc.com is gated (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/.github/workflows/ci_e2e_pay_tests.yml
+++ b/.github/workflows/ci_e2e_pay_tests.yml
@@ -82,11 +82,13 @@ jobs:
           # produce an inconsistent incremental APK whose dex is missing classes.
           ./gradlew clean :sample:wallet:assembleInternal --no-build-cache
 
+      # Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
+      # / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer copied.
       - name: Copy Maestro Pay test flows
-        uses: WalletConnect/actions/maestro/pay-tests@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/pay-tests@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Install Maestro
-        uses: WalletConnect/actions/maestro/setup@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/setup@28181b5f133836380d2d9bb8ff06af5c3234fb9d
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -198,7 +200,7 @@ jobs:
       - name: Reset USDT Permit2 allowance (Polygon)
         if: always()
         continue-on-error: true
-        uses: WalletConnect/actions/maestro/permit2-reset@ddc7c0f9acd8b1576e9a78f0ef67f4b8fbb36db2
+        uses: WalletConnect/actions/maestro/permit2-reset@28181b5f133836380d2d9bb8ff06af5c3234fb9d
         with:
           chain-id: eip155:137
           # polygon-rpc.com is gated (HTTP 401 "tenant disabled") in CI; use publicnode.

--- a/sample/wallet/src/main/AndroidManifest.xml
+++ b/sample/wallet/src/main/AndroidManifest.xml
@@ -73,33 +73,6 @@
                     android:scheme="https" />
             </intent-filter>
 
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" android:host="pay.walletconnect.com" />
-            </intent-filter>
-
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" android:host="staging.pay.walletconnect.com" />
-            </intent-filter>
-
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" android:host="dev.pay.walletconnect.com" />
-            </intent-filter>
-
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
@@ -134,21 +107,6 @@
             <meta-data
                 android:name="android.nfc.action.TECH_DISCOVERED"
                 android:resource="@xml/nfc_tech_filter" />
-
-            <!-- Android App Links: when the browser opens the payment URL from NFC,
-                 App Links auto-redirects to this activity (if wallet is installed).
-                 Requires /.well-known/assetlinks.json on the payment domain. -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="pay.walletconnect.com" />
-                <data
-                    android:scheme="https"
-                    android:host="staging.pay.walletconnect.com" />
-            </intent-filter>
         </activity>
 
         <service

--- a/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/WalletKitActivity.kt
+++ b/sample/wallet/src/main/kotlin/com/reown/sample/wallet/ui/WalletKitActivity.kt
@@ -238,7 +238,10 @@ class WalletKitActivity : AppCompatActivity() {
         }
 
         val dataString = intent?.dataString
-        // Check for WalletConnect Pay URL - pass the full link (URL encoded)
+        // Check for WalletConnect Pay URL - pass the full link (URL encoded).
+        // Universal-link registration for the pay.walletconnect.* hosts was removed from
+        // the manifest, so on native these URLs now arrive via NFC (handled above) rather
+        // than a tapped App Link; this branch remains for any URL dispatched into the app.
         if (dataString != null && isPaymentUrl(dataString)) {
             lifecycleScope.launch {
                 navigateWhenReady { nav ->

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Downloads shared WalletConnect Pay Maestro test flows from WalletConnect/actions repo.
 # Usage: ./scripts/setup-maestro-pay-tests.sh [ref]
-#   ref: actions repo branch/tag/commit to pull from (default: 28181b5f133836380d2d9bb8ff06af5c3234fb9d)
+#   ref: actions repo branch/tag/commit to pull from (default: 4be7c0112f9651fc63b18c137650b75d2fc9b200)
 
 set -euo pipefail
 
-# Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
+# Pinned to WalletConnect/actions #109 merge (4be7c01 = removal of the Universal Link
 # / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer downloaded.
-REF="${1:-28181b5f133836380d2d9bb8ff06af5c3234fb9d}"
+REF="${1:-4be7c0112f9651fc63b18c137650b75d2fc9b200}"
 REPO="WalletConnect/actions"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/setup-maestro-pay-tests.sh
+++ b/scripts/setup-maestro-pay-tests.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # Downloads shared WalletConnect Pay Maestro test flows from WalletConnect/actions repo.
 # Usage: ./scripts/setup-maestro-pay-tests.sh [ref]
-#   ref: actions repo branch/tag/commit to pull from (default: d385e7a80fb4a3d378ee685021f3f7e24ccdf291)
+#   ref: actions repo branch/tag/commit to pull from (default: 28181b5f133836380d2d9bb8ff06af5c3234fb9d)
 
 set -euo pipefail
 
-REF="${1:-d385e7a80fb4a3d378ee685021f3f7e24ccdf291}"
+# Pinned to WalletConnect/actions #109 (28181b5 = removal of the Universal Link
+# / deeplink pay flow), so pay_single_option_nokyc_deeplink is no longer downloaded.
+REF="${1:-28181b5f133836380d2d9bb8ff06af5c3234fb9d}"
 REPO="WalletConnect/actions"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary

Universal linking is no longer in scope for the wallet Maestro pay suite — [WalletConnect/actions#109](https://github.com/WalletConnect/actions/pull/109) removed the Universal Link pay test (`pay_single_option_nokyc_deeplink.yaml`) from the shared suite. This PR strips the infrastructure in this repo that existed **only** to make that test pass. Pay links still reach the wallet via **NFC** (POS tap).

Mirrors react-native-examples [#563](https://github.com/reown-com/react-native-examples/pull/563) for the Android wallet sample. The RN PR's iOS-only parts (signing removal, `swcutil`/AASA simulator-boot cleanup) and its web-skip block have no Android analog and are omitted.

## Changes

- **Stop registering `pay.walletconnect.*` App Links** (`AndroidManifest.xml`): remove the `autoVerify` `VIEW`/`BROWSABLE` intent filters for `pay.walletconnect.com` / `staging.` / `dev.` from `WalletKitActivity`, and the equivalent App Links filter from `NfcPaymentActivity`. Kept the `appkit-lab.reown.com` link-mode entry, the `kotlin-web3wallet://` custom schemes, and — crucially — the NFC `NDEF_DISCOVERED` / `TECH_DISCOVERED` filters. Pay links now arrive via NFC, not a tapped App Link.
- **Keep the Kotlin pay-link handler** (`WalletKitActivity.kt`): `handleAppLink()` / `isPaymentUrl()` are unchanged; only the comment is clarified to note these URLs now arrive via NFC.
- **Bump the shared-flows pins** (`ci_e2e_pay_tests.yml`): `pay-tests`, `setup`, `permit2-reset` re-pointed to the 109 merge commit (`4be7c01`) so the deeplink flow is no longer downloaded.
- **Bump the local flow-download default** (`setup-maestro-pay-tests.sh`): re-pointed to the 109 merge commit (`4be7c01`) for parity with CI.

`claude-review.yml`'s `d385e7a` pin (unrelated `claude/auto-review` action) is intentionally left untouched.

## Testing

E2E Pay tests (`ci_e2e_pay_tests.yml`, `--include-tags pay`) pass on this branch. The deeplink flow no longer runs; the remaining pay flows are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)