### PR TITLE
build: bump AGP to 9.2.0 (Gradle 9.4.1) to fix E2E Pay dex-verify flake

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.4.0"
 moshix = "0.36.0"
 kotlinxCoroutinesCore = "1.11.0"
 kotlinxCoroutinesTest = "1.11.0"
-agp = "9.1.1"
+agp = "9.2.0"
 
 minSdk = "23"
 mockkAndroid = "1.14.11"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 01 11:19:21 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Problem

The scheduled **E2E Pay Tests with Maestro** job fails intermittently. It dies at the pre-Maestro smoke check because the app crashes on launch:

```
Unable to instantiate application com.reown.sample.wallet.WalletKitApplication
  Caused by: ClassNotFoundException: WalletKitApplication  (from base.apk)
```

## Root cause (corrected)

Not R8 *stripping* the class — the class is present. Immediately before the crash, ART logs:

```
Failure to verify dex file 'base.apk!classesN.dex':
  Out-of-order annotation_element name_idx: X then X
```

R8 (running in compat mode) emits a dex containing a **structurally invalid annotation** (duplicate / non-ascending `annotation_element name_idx`). API 34+ ART enforces the dex spec, **rejects the entire dex file, and discards it** — so every class in that dex (including `WalletKitApplication` / `androidx.core.app.CoreComponentFactory`) becomes unresolvable.

It's flaky because R8's multithreaded dexing partitions classes into `classes2/3/4.dex` nondeterministically — the malformed annotation and the manifest classes only sometimes land in the same rejected dex. Confirmed across two failures: `classes2.dex … name_idx 10024 then 10024` (07-10) and `classes3.dex … name_idx d991 then d991` (07-14).

## Fix

Bump **AGP 9.1.1 → 9.2.0**. AGP 9.2.0 tightens `-keepattributes` semantics so `*Annotation*` (which `sample/wallet/proguard-rules.pro` uses) no longer retains runtime-*invisible* annotations — the likely source of the malformed element. R8 then stops emitting them, so the invalid dex is never produced.

This fixes R8's actual output, so it covers **both** the CI E2E build **and** the shipped Firebase/`release` builds (same minified path) — unlike disabling minification, which would only mask CI.

AGP 9.2.0 requires **Gradle 9.4.1**, so the wrapper is bumped too.

## Verification

- `./gradlew :sample:wallet:help` configures cleanly on Gradle 9.4.1 / AGP 9.2.0 (only Kotlin-plugin deprecation *warnings*).
- `./gradlew clean :sample:wallet:assembleInternal --no-build-cache` builds successfully, including `minifyInternalWithR8`.

Because the underlying bug is intermittent, a single green CI run doesn't prove it fixed — the E2E job should be watched over several runs (or exercised with a repeat-build loop) to confirm the malformed dex no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)