### PR TITLE
fix(appkit): route SIWE connections through connect with authentication requests

### DIFF
--- a/product/appkit/src/main/kotlin/com/reown/appkit/client/ClientMapper.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/client/ClientMapper.kt
@@ -8,7 +8,10 @@ import com.reown.appkit.client.models.request.Request
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
-internal fun Sign.Model.ApprovedSession.toModal() = Modal.Model.ApprovedSession.WalletConnectSession(topic, metaData, namespaces.toModal(), accounts)
+internal fun Sign.Model.ApprovedSession.toModal() =
+    Modal.Model.ApprovedSession.WalletConnectSession(topic, metaData, namespaces.toModal(), accounts, proposalRequestsResponses?.toModal())
+
+internal fun Sign.Model.ProposalRequestsResponses.toModal() = Modal.Model.ProposalRequestsResponses(authentication = authentication?.toClient())
 
 internal fun Map<String, Sign.Model.Namespace.Session>.toModal() =
     mapValues { (_, namespace) -> Modal.Model.Namespace.Session(namespace.chains, namespace.accounts, namespace.methods, namespace.events) }

--- a/product/appkit/src/main/kotlin/com/reown/appkit/client/Modal.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/client/Modal.kt
@@ -125,6 +125,7 @@ object Modal {
                 val metaData: Core.Model.AppMetaData?,
                 val namespaces: Map<String, Namespace.Session>,
                 val accounts: List<String>,
+                val proposalRequestsResponses: ProposalRequestsResponses? = null,
             ) : ApprovedSession()
 
             data class CoinbaseSession(
@@ -245,6 +246,10 @@ object Modal {
                 val address: String get() = Issuer(iss).address
             }
         }
+
+        data class ProposalRequestsResponses(
+            val authentication: List<Cacao>?
+        ) : Model()
 
         sealed class Ping : Model() {
             data class Success(val topic: String) : Ping()

--- a/product/appkit/src/main/kotlin/com/reown/appkit/ui/components/internal/AppKitComponent.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/ui/components/internal/AppKitComponent.kt
@@ -66,7 +66,9 @@ internal fun AppKitComponent(
                 when (event) {
                     is Modal.Model.SIWEAuthenticateResponse.Result, is Modal.Model.SessionAuthenticateResponse.Result -> closeModal()
                     is Modal.Model.ApprovedSession -> {
-                        if (AppKit.authPayloadParams != null) {
+                        val isAuthenticated = (event as? Modal.Model.ApprovedSession.WalletConnectSession)
+                            ?.proposalRequestsResponses?.authentication?.isNotEmpty() == true
+                        if (AppKit.authPayloadParams != null && !isAuthenticated) {
                             navController.navigate(Route.SIWE_FALLBACK.path)
                         } else {
                             closeModal()

--- a/product/appkit/src/main/kotlin/com/reown/appkit/ui/routes/connect/ConnectViewModel.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/ui/routes/connect/ConnectViewModel.kt
@@ -3,6 +3,7 @@ package com.reown.appkit.ui.routes.connect
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.reown.android.internal.common.modal.data.model.Wallet
+import com.reown.android.internal.common.model.AppMetaData
 import com.reown.android.internal.common.wcKoinApp
 import com.reown.android.pulse.domain.SendEventInterface
 import com.reown.android.pulse.model.ConnectionMethod
@@ -45,6 +46,7 @@ internal class ConnectViewModel : ViewModel(), Navigator by NavigatorImpl(), Par
     private val observeSelectedChainUseCase: ObserveSelectedChainUseCase = wcKoinApp.koin.get()
     private val appKitEngine: AppKitEngine = wcKoinApp.koin.get()
     private val sendEventUseCase: SendEventInterface = wcKoinApp.koin.get()
+    private val selfAppMetaData: AppMetaData = wcKoinApp.koin.get()
     private var sessionParams: Modal.Params.SessionParams = getSessionParamsSelectedChain()
     val selectedChain = observeSelectedChainUseCase().map { savedChainId ->
         AppKit.chains.find { it.id == savedChainId } ?: appKitEngine.getSelectedChainOrFirst()
@@ -160,11 +162,13 @@ internal class ConnectViewModel : ViewModel(), Navigator by NavigatorImpl(), Par
     }
 
     fun connectWalletConnect(name: String, method: String, linkMode: String?, onSuccess: (String) -> Unit) {
-        if (AppKit.authPayloadParams != null) {
+        val authPayloadParams = getAuthPayloadParams()
+        if (authPayloadParams != null && isLinkModeConnection(linkMode)) {
+            // Link Mode delivers wc_sessionAuthenticate over an app link (no relay), so it stays on the authenticate flow
             authenticate(
                 name, method,
                 walletAppLink = linkMode,
-                authParams = if (AppKit.selectedChain != null) AppKit.authPayloadParams!!.copy(chains = listOf(AppKit.selectedChain!!.id)) else AppKit.authPayloadParams!!,
+                authParams = authPayloadParams,
                 onSuccess = { onSuccess(it) },
                 onError = {
                     sendEventUseCase.send(Props(EventType.TRACK, EventType.Track.CONNECT_ERROR, Properties(message = it.message ?: "Relay error while connecting")))
@@ -176,6 +180,7 @@ internal class ConnectViewModel : ViewModel(), Navigator by NavigatorImpl(), Par
             connect(
                 name, method,
                 sessionParams = sessionParams,
+                authPayloadParams = authPayloadParams,
                 onSuccess = onSuccess,
                 onError = {
                     sendEventUseCase.send(Props(EventType.TRACK, EventType.Track.CONNECT_ERROR, Properties(message = it.message ?: "Relay error while connecting")))
@@ -185,6 +190,14 @@ internal class ConnectViewModel : ViewModel(), Navigator by NavigatorImpl(), Par
             )
         }
     }
+
+    private fun getAuthPayloadParams(): Modal.Model.AuthPayloadParams? =
+        AppKit.authPayloadParams?.let { params ->
+            AppKit.selectedChain?.let { chain -> params.copy(chains = listOf(chain.id)) } ?: params
+        }
+
+    private fun isLinkModeConnection(linkMode: String?): Boolean =
+        !linkMode.isNullOrEmpty() && selfAppMetaData.redirect?.linkMode == true
 
     fun connectCoinbase(onSuccess: () -> Unit = {}) {
         appKitEngine.connectCoinbase(

--- a/product/appkit/src/main/kotlin/com/reown/appkit/ui/routes/connect/ParingController.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/ui/routes/connect/ParingController.kt
@@ -12,6 +12,7 @@ internal interface ParingController {
     fun connect(
         name: String, method: String,
         sessionParams: Modal.Params.SessionParams,
+        authPayloadParams: Modal.Model.AuthPayloadParams? = null,
         onSuccess: (uri: String) -> Unit,
         onError: (Throwable) -> Unit
     )
@@ -40,6 +41,7 @@ internal class PairingControllerImpl : ParingController {
     override fun connect(
         name: String, method: String,
         sessionParams: Modal.Params.SessionParams,
+        authPayloadParams: Modal.Model.AuthPayloadParams?,
         onSuccess: (uri: String) -> Unit,
         onError: (Throwable) -> Unit
     ) {
@@ -49,7 +51,8 @@ internal class PairingControllerImpl : ParingController {
                 sessionParams.optionalNamespaces,
                 sessionParams.properties,
                 sessionParams.scopedProperties,
-                pairing
+                pairing,
+                authentication = authPayloadParams?.let { listOf(it.toModel(pairing.topic)) }
             )
             appKitEngine.connectWC(
                 name = name, method = method,


### PR DESCRIPTION
## Problem

Fixes #415 — `proposeSession` intermittently fails with `-32603 Topic repository: AlreadyExists` / `-32000 Topic service: AlreadyExists` on a fresh pairing topic, the error toast shows in the modal, the wallet is never deep-linked, and a manually copied URI hangs on "Connecting..." because the proposal was never stored on the relay.

## Root cause

When `AppKit.setAuthRequestParams` is set (SIWE), the modal routed every relay connection through the deprecated `authenticate()` flow (`SessionAuthenticateUseCase`), which makes **two writes on the same fresh pairing topic**:

1. `wc_sessionAuthenticate` via classic `irn_publish` — this registers the topic on the relay
2. the fallback session proposal via the **`wc_proposeSession` relay method** — which requires creating that same topic → `AlreadyExists`

The relay recently started enforcing exclusive topic creation in `wc_proposeSession`, which is why this surfaced without SDK changes. The JS SDK never mixes the two transports on one topic (its authenticate fallback uses `irn_publish` for both), which is why AppKit web does not reproduce.

## Changes

- `ConnectViewModel.connectWalletConnect`: relay connections with auth params now use `connect()` with the auth request embedded in the session proposal (`ConnectParams.authentication`) — a single `wc_proposeSession`, matching the JS SDK. Link Mode connections keep using `authenticate()`, as they deliver `wc_sessionAuthenticate` over the wallet app link without touching the relay.
- `ParingController.connect` accepts optional `authPayloadParams` and builds `ConnectParams.authentication` from it.
- `Modal.Model.ApprovedSession.WalletConnectSession` gains `proposalRequestsResponses` (additive, defaults to `null`) so the signed cacaos returned in the session settle reach the dApp — the Sign layer already returned them, the AppKit mapper dropped them.
- `AppKitComponent` skips the SIWE `personal_sign` fallback screen when the wallet already authenticated via the proposal-embedded request; otherwise the fallback behaves as before.

## Testing

- Reproduced `AlreadyExists` reliably with the modal sample on `develop`; after this change the same flow connects cleanly (proposal-only `wc_proposeSession`), wallet deep-links, and the SIWE fallback appears after settle as expected.
- `:product:appkit:testDebugUnitTest` — the 6 failing Paparazzi snapshot tests fail identically on clean `develop` (pre-existing, unrelated).

## Notes

- Integrators on published versions (e.g. 1.6.14) remain affected until they upgrade — relay-side idempotency for `wc_proposeSession` topic creation is worth pursuing in parallel.
- The deprecated `SignClient.authenticate()` relay path still dual-publishes and can hit `AlreadyExists` when called directly; left untouched here by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)