### PR TITLE
feat(dapp-sample): WalletConnect Pay WebView checkout screen

### DIFF
--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/DappSampleApp.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/DappSampleApp.kt
@@ -16,6 +16,13 @@ import com.reown.appkit.utils.EthUtils
 import timber.log.Timber
 import com.reown.sample.common.BuildConfig as CommonBuildConfig
 
+/**
+ * The dapp's registered return deep link. Wallets route back here after signing, and the Pay
+ * WebView passes it as its `returnUrl`. Must stay in sync with the `kotlin-dapp-wc` scheme +
+ * `request` host intent-filter declared in AndroidManifest.xml.
+ */
+const val DAPP_RETURN_DEEP_LINK = "kotlin-dapp-wc://request"
+
 class DappSampleApp : Application() {
 
     override fun onCreate() {
@@ -26,7 +33,7 @@ class DappSampleApp : Application() {
             description = "Kotlin Dapp Implementation",
             url = "https://appkit-lab.reown.com",
             icons = listOf("https://gblobscdn.gitbook.com/spaces%2F-LJJeCjcLrr53DcT1Ml7%2Favatar.png?alt=media"),
-            redirect = "kotlin-dapp-wc://request",
+            redirect = DAPP_RETURN_DEEP_LINK,
             appLink = BuildConfig.DAPP_APP_LINK,
             linkMode = true
         )

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/DappSampleNavGraph.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/DappSampleNavGraph.kt
@@ -2,6 +2,7 @@
 package com.reown.sample.dapp.ui
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -17,6 +18,7 @@ import androidx.compose.material.navigation.ModalBottomSheetLayout
 import com.reown.sample.dapp.ui.routes.Route
 import com.reown.sample.dapp.ui.routes.composable_routes.account.AccountRoute
 import com.reown.sample.dapp.ui.routes.composable_routes.chain_selection.ChainSelectionRoute
+import com.reown.sample.dapp.ui.routes.composable_routes.pay.PayWebViewRoute
 import com.reown.sample.dapp.ui.routes.composable_routes.session.SessionRoute
 import com.reown.appkit.ui.appKitGraph
 
@@ -50,6 +52,13 @@ fun DappSampleNavGraph(
             ) {
                 AccountRoute(navController)
             }
+            composable(
+                route = Route.Pay.path + "/{$payUrlArg}",
+                arguments = listOf(navArgument(payUrlArg) { type = NavType.StringType })
+            ) { backStackEntry ->
+                val encoded = backStackEntry.arguments?.getString(payUrlArg).orEmpty()
+                PayWebViewRoute(navController, gatewayUrl = Uri.decode(encoded))
+            }
             appKitGraph(navController)
         }
     }
@@ -58,4 +67,9 @@ fun DappSampleNavGraph(
 const val accountArg = "accountArg"
 fun NavController.navigateToAccount(selectedAccount: String) {
     navigate(Route.Account.path + "/$selectedAccount")
+}
+
+const val payUrlArg = "payUrlArg"
+fun NavController.navigateToPay(gatewayUrl: String) {
+    navigate(Route.Pay.path + "/" + Uri.encode(gatewayUrl))
 }

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/Route.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/Route.kt
@@ -4,4 +4,5 @@ sealed class Route(val path: String) {
     object ChainSelection : Route("chain_selection")
     object Session : Route("session")
     object Account : Route("account")
+    object Pay : Route("pay")
 }

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/chain_selection/ChainSelectionRoute.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/chain_selection/ChainSelectionRoute.kt
@@ -244,10 +244,11 @@ private fun ChainSelectionScreen(
                 text = "Open Pay checkout",
                 onClick = {
                     val url = payUrl.trim()
-                    if (Uri.parse(url).scheme == "https") {
+                    // URI schemes are case-insensitive, so normalize before comparing.
+                    if (Uri.parse(url).scheme?.equals("https", ignoreCase = true) == true) {
                         onOpenPayUrl(url)
                     } else {
-                        Toast.makeText(context, "Enter a valid https:// Pay URL", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, "Enter a valid Pay URL starting with https://", Toast.LENGTH_SHORT).show()
                     }
                 },
                 modifier = Modifier

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/chain_selection/ChainSelectionRoute.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/chain_selection/ChainSelectionRoute.kt
@@ -3,6 +3,7 @@ package com.reown.sample.dapp.ui.routes.composable_routes.chain_selection
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,6 +27,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -73,6 +75,7 @@ import com.reown.sample.common.ui.themedColor
 import com.reown.sample.common.ui.toColor
 import com.reown.sample.dapp.BuildConfig
 import com.reown.sample.dapp.ui.DappSampleEvents
+import com.reown.sample.dapp.ui.navigateToPay
 import com.reown.sample.dapp.ui.routes.Route
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -103,7 +106,8 @@ fun ChainSelectionRoute(navController: NavController, dispatcher: CoroutineDispa
         onConnectClick = { onConnectClick(viewModel, navController, context) },
         onAuthenticateClick = {
             onAuthenticate(viewModel, composableScope, dispatcher, context) { uri -> pairingUri = uri }
-        }
+        },
+        onOpenPayUrl = { url -> navController.navigateToPay(url) }
     )
 }
 
@@ -192,7 +196,9 @@ private fun ChainSelectionScreen(
     onChainClick: (Int, Boolean) -> Unit,
     onConnectClick: () -> Unit,
     onAuthenticateClick: () -> Unit,
+    onOpenPayUrl: (String) -> Unit,
 ) {
+    var payUrl by remember { mutableStateOf("") }
     Box {
         Column(modifier = Modifier.fillMaxSize()) {
             WCTopAppBarLegacy(titleText = "Chain selection")
@@ -216,6 +222,34 @@ private fun ChainSelectionScreen(
             BlueButton(
                 text = "1-CA",
                 onClick = onAuthenticateClick,
+                modifier = Modifier
+                    .padding(vertical = 10.dp)
+                    .fillMaxWidth()
+                    .height(50.dp)
+                    .padding(horizontal = 16.dp)
+            )
+
+            // WalletConnect Pay: paste a gateway URL to open the hosted checkout in a WebView.
+            OutlinedTextField(
+                value = payUrl,
+                onValueChange = { payUrl = it },
+                label = { Text("WalletConnect Pay URL") },
+                placeholder = { Text("https://pay.walletconnect.com/...") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+            BlueButton(
+                text = "Open Pay checkout",
+                onClick = {
+                    val url = payUrl.trim()
+                    if (Uri.parse(url).scheme == "https") {
+                        onOpenPayUrl(url)
+                    } else {
+                        Toast.makeText(context, "Enter a valid https:// Pay URL", Toast.LENGTH_SHORT).show()
+                    }
+                },
                 modifier = Modifier
                     .padding(vertical = 10.dp)
                     .fillMaxWidth()
@@ -512,7 +546,8 @@ private fun ChainSelectionScreenPreview(@PreviewParameter(ChainSelectionStatePro
             onDialogDismiss = {},
             onChainClick = { _, _ -> },
             onConnectClick = {},
-            onAuthenticateClick = {}
+            onAuthenticateClick = {},
+            onOpenPayUrl = {}
         )
     }
 }

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
@@ -1,6 +1,7 @@
 package com.reown.sample.dapp.ui.routes.composable_routes.pay
 
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Handler
@@ -115,6 +116,11 @@ private fun PayWebViewContent(
     val currentOnSuccess by rememberUpdatedState(onSuccess)
     val currentOnFailure by rememberUpdatedState(onFailure)
 
+    // Hold a direct reference to the WebView so `onRelease` can tear it down deterministically,
+    // rather than fishing it out of the FrameLayout by child index. Remembered so it survives
+    // recompositions (e.g. the `isLoading` toggle) — `onRelease` runs on a later composition.
+    val webViewRef = remember { mutableStateOf<WebView?>(null) }
+
     Box(modifier = Modifier.fillMaxSize()) {
         AndroidView(
             modifier = Modifier.fillMaxSize(),
@@ -151,25 +157,20 @@ private fun PayWebViewContent(
                         )
 
                         webViewClient = object : WebViewClient() {
+                            // API 24+ overload.
                             override fun shouldOverrideUrlLoading(
                                 view: WebView?,
                                 request: WebResourceRequest?
-                            ): Boolean {
-                                val reqUrl = request?.url?.toString() ?: return false
-                                if (isWalletDeeplink(reqUrl)) {
-                                    try {
-                                        context.startActivity(
-                                            Intent(Intent.ACTION_VIEW, Uri.parse(reqUrl))
-                                        )
-                                    } catch (_: ActivityNotFoundException) {
-                                        // No app can handle the wallet deeplink (wallet not installed).
-                                    }
-                                    return true
-                                }
-                                // Load everything else in-place. Only wallet `wc:` deeplinks are
-                                // forwarded to the OS — other non-https schemes are simply not routed.
-                                return false
-                            }
+                            ): Boolean = handleWalletDeeplink(context, request?.url?.toString())
+
+                            // Deprecated pre-API-24 overload — still the only one called on API 23
+                            // (the repo's minSdk), so without it deeplink interception silently
+                            // no-ops there and `wc:` links would load inside the WebView.
+                            @Suppress("DEPRECATION")
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                url: String?
+                            ): Boolean = handleWalletDeeplink(context, url)
 
                             override fun onPageFinished(view: WebView?, url: String?) {
                                 isLoading = false
@@ -179,11 +180,12 @@ private fun PayWebViewContent(
                         loadUrl(buildPayUrl(gatewayUrl, APP_DEEP_LINK))
                     }
 
+                    webViewRef.value = webView
                     addView(webView)
                 }
             },
-            onRelease = { frameLayout ->
-                (frameLayout.getChildAt(0) as? WebView)?.apply {
+            onRelease = {
+                webViewRef.value?.apply {
                     removeJavascriptInterface("ReactNativeWebView")
                     stopLoading()
                     webViewClient = WebViewClient()
@@ -191,6 +193,7 @@ private fun PayWebViewContent(
                     (parent as? android.view.ViewGroup)?.removeView(this)
                     destroy()
                 }
+                webViewRef.value = null
             }
         )
 
@@ -306,4 +309,23 @@ internal fun isWalletDeeplink(url: String): Boolean = try {
     Uri.parse(url).getQueryParameter("uri")?.startsWith("wc:") == true
 } catch (_: Exception) {
     false
+}
+
+/**
+ * Shared interception logic for both `shouldOverrideUrlLoading` overloads. Forwards `wc:` wallet
+ * deeplinks to the OS and returns `true` (handled); returns `false` for everything else so the
+ * WebView loads it in-place. Only `wc:` links are forwarded — other non-https schemes are never
+ * routed to the OS.
+ */
+private fun handleWalletDeeplink(context: Context, url: String?): Boolean {
+    if (url == null) return false
+    if (isWalletDeeplink(url)) {
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        } catch (_: ActivityNotFoundException) {
+            // No app can handle the wallet deeplink (wallet not installed).
+        }
+        return true
+    }
+    return false
 }

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
@@ -1,0 +1,309 @@
+package com.reown.sample.dapp.ui.routes.composable_routes.pay
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.navigation.NavHostController
+import com.reown.sample.common.ui.commons.BlueButton
+import com.reown.sample.common.ui.theme.WCTheme
+import com.reown.sample.dapp.BuildConfig
+import org.json.JSONObject
+
+/**
+ * Embeds the WalletConnect Pay checkout portal inside a native WebView.
+ *
+ * Ported from the React Native reference (reown-com/react-native-examples PRs #570/#576) and the
+ * "Buyer Experience — WebView Integration" doc. The hosted UI drives wallet selection, payment option
+ * display, compliance data collection, and signing orchestration; this screen only:
+ *  - loads the [gatewayUrl] with `returnUrl` + `preferUniversalLinks=1` appended,
+ *  - forwards `?uri=wc:` wallet deeplinks to the OS (WebViews can't route them natively),
+ *  - listens for `PAY_SUCCESS` / `PAY_FAILURE` bridge messages via `window.ReactNativeWebView`.
+ *
+ * The app's registered deep link ([APP_DEEP_LINK]) is passed as the return destination so the wallet
+ * can route the user back after signing. [DappSampleActivity] is `singleTask`, so the return simply
+ * foregrounds the existing task — the WebView survives and the checkout resumes.
+ */
+@Composable
+fun PayWebViewRoute(
+    navController: NavHostController,
+    gatewayUrl: String,
+) {
+    var result by remember { mutableStateOf<PayResult>(PayResult.InProgress) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(WCTheme.colors.bgPrimary)
+            .statusBarsPadding()
+    ) {
+        when (val current = result) {
+            is PayResult.InProgress -> PayWebViewContent(
+                gatewayUrl = gatewayUrl,
+                onSuccess = { message -> result = PayResult.Success(message) },
+                onFailure = { error -> result = PayResult.Failure(error) },
+            )
+
+            is PayResult.Success -> PayResultContent(
+                isSuccess = true,
+                title = current.message ?: "Payment confirmed",
+                actionLabel = "Done",
+                onAction = { navController.popBackStack() },
+            )
+
+            is PayResult.Failure -> PayResultContent(
+                isSuccess = false,
+                title = current.error ?: "Payment failed",
+                actionLabel = "Close",
+                onAction = { navController.popBackStack() },
+            )
+        }
+    }
+}
+
+private sealed interface PayResult {
+    data object InProgress : PayResult
+    data class Success(val message: String?) : PayResult
+    data class Failure(val error: String?) : PayResult
+}
+
+@Composable
+private fun PayWebViewContent(
+    gatewayUrl: String,
+    onSuccess: (String?) -> Unit,
+    onFailure: (String?) -> Unit,
+) {
+    var isLoading by remember { mutableStateOf(true) }
+
+    // Wrap the callbacks so the WebView's JS bridge (registered once in `factory`) always invokes the
+    // latest lambdas rather than the ones captured at first composition.
+    val currentOnSuccess by rememberUpdatedState(onSuccess)
+    val currentOnFailure by rememberUpdatedState(onFailure)
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { context ->
+                // Wrap the WebView in a FrameLayout to isolate it from Compose's rendering (matches
+                // the wallet sample's PaymentRoute and avoids input/scroll glitches).
+                FrameLayout(context).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT
+                    )
+
+                    val webView = WebView(context).apply {
+                        layoutParams = FrameLayout.LayoutParams(
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                            FrameLayout.LayoutParams.MATCH_PARENT
+                        )
+
+                        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
+
+                        settings.javaScriptEnabled = true
+                        settings.domStorageEnabled = true
+                        settings.allowFileAccess = false
+                        settings.allowContentAccess = false
+
+                        addJavascriptInterface(
+                            PayJsBridge(
+                                onSuccess = { message -> currentOnSuccess(message) },
+                                onFailure = { error -> currentOnFailure(error) },
+                            ),
+                            // The hosted checkout calls window.ReactNativeWebView.postMessage(json)
+                            // on every platform; the bridge name must match exactly.
+                            "ReactNativeWebView"
+                        )
+
+                        webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                request: WebResourceRequest?
+                            ): Boolean {
+                                val reqUrl = request?.url?.toString() ?: return false
+                                if (isWalletDeeplink(reqUrl)) {
+                                    try {
+                                        context.startActivity(
+                                            Intent(Intent.ACTION_VIEW, Uri.parse(reqUrl))
+                                        )
+                                    } catch (_: ActivityNotFoundException) {
+                                        // No app can handle the wallet deeplink (wallet not installed).
+                                    }
+                                    return true
+                                }
+                                // Load everything else in-place. Only wallet `wc:` deeplinks are
+                                // forwarded to the OS — other non-https schemes are simply not routed.
+                                return false
+                            }
+
+                            override fun onPageFinished(view: WebView?, url: String?) {
+                                isLoading = false
+                            }
+                        }
+
+                        loadUrl(buildPayUrl(gatewayUrl, APP_DEEP_LINK))
+                    }
+
+                    addView(webView)
+                }
+            },
+            onRelease = { frameLayout ->
+                (frameLayout.getChildAt(0) as? WebView)?.apply {
+                    removeJavascriptInterface("ReactNativeWebView")
+                    stopLoading()
+                    webViewClient = WebViewClient()
+                    loadUrl("about:blank")
+                    (parent as? android.view.ViewGroup)?.removeView(this)
+                    destroy()
+                }
+            }
+        )
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(WCTheme.colors.bgPrimary),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = WCTheme.colors.bgAccentPrimary)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PayResultContent(
+    isSuccess: Boolean,
+    title: String,
+    actionLabel: String,
+    onAction: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(WCTheme.colors.bgPrimary)
+            .padding(WCTheme.spacing.spacing5),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .background(if (isSuccess) WCTheme.colors.iconSuccess else WCTheme.colors.textError),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = if (isSuccess) "✓" else "!",
+                color = Color.White,
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(WCTheme.spacing.spacing5))
+
+        Text(
+            text = title,
+            style = WCTheme.typography.h6Regular.copy(color = WCTheme.colors.textPrimary),
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(WCTheme.spacing.spacing6))
+
+        // NOTE: In production, treat PAY_SUCCESS only as a trigger to confirm the payment
+        // server-side via GET /v1/payments/{paymentId}/status — never as proof on its own.
+        BlueButton(
+            text = actionLabel,
+            onClick = onAction,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+        )
+    }
+}
+
+/** WebView -> native bridge. Methods run on a background thread, so hop to the main thread. */
+private class PayJsBridge(
+    private val onSuccess: (String?) -> Unit,
+    private val onFailure: (String?) -> Unit,
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @JavascriptInterface
+    fun postMessage(json: String) {
+        val msg = try {
+            JSONObject(json)
+        } catch (_: Exception) {
+            return
+        }
+        val type = msg.optString("type")
+        val hasSuccess = msg.has("success")
+        val success = msg.optBoolean("success", false)
+        mainHandler.post {
+            when {
+                type == "PAY_SUCCESS" || (hasSuccess && success) ->
+                    onSuccess(msg.optString("message").ifEmpty { null })
+
+                type == "PAY_FAILURE" || (hasSuccess && !success) ->
+                    onFailure(msg.optString("error").ifEmpty { null })
+            }
+        }
+    }
+}
+
+private const val APP_DEEP_LINK = "kotlin-dapp-wc://request"
+
+/**
+ * Appends the two required WebView params to the API-provided gateway URL. Never construct the base
+ * URL manually — start from the `gatewayUrl` the Merchant API returns.
+ */
+internal fun buildPayUrl(gatewayUrl: String, appDeepLink: String): String =
+    Uri.parse(gatewayUrl).buildUpon()
+        .appendQueryParameter("returnUrl", appDeepLink)
+        .appendQueryParameter("preferUniversalLinks", "1")
+        .build()
+        .toString()
+
+/** A navigation is a wallet deeplink when it carries a `?uri=wc:` query parameter. */
+internal fun isWalletDeeplink(url: String): Boolean = try {
+    Uri.parse(url).getQueryParameter("uri")?.startsWith("wc:") == true
+} catch (_: Exception) {
+    false
+}

--- a/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
+++ b/sample/dapp/src/main/kotlin/com/reown/sample/dapp/ui/routes/composable_routes/pay/PayWebViewRoute.kt
@@ -44,6 +44,7 @@ import androidx.navigation.NavHostController
 import com.reown.sample.common.ui.commons.BlueButton
 import com.reown.sample.common.ui.theme.WCTheme
 import com.reown.sample.dapp.BuildConfig
+import com.reown.sample.dapp.DAPP_RETURN_DEEP_LINK
 import org.json.JSONObject
 
 /**
@@ -56,7 +57,7 @@ import org.json.JSONObject
  *  - forwards `?uri=wc:` wallet deeplinks to the OS (WebViews can't route them natively),
  *  - listens for `PAY_SUCCESS` / `PAY_FAILURE` bridge messages via `window.ReactNativeWebView`.
  *
- * The app's registered deep link ([APP_DEEP_LINK]) is passed as the return destination so the wallet
+ * The app's registered deep link ([DAPP_RETURN_DEEP_LINK]) is passed as the return destination so the wallet
  * can route the user back after signing. [DappSampleActivity] is `singleTask`, so the return simply
  * foregrounds the existing task — the WebView survives and the checkout resumes.
  */
@@ -177,7 +178,7 @@ private fun PayWebViewContent(
                             }
                         }
 
-                        loadUrl(buildPayUrl(gatewayUrl, APP_DEEP_LINK))
+                        loadUrl(buildPayUrl(gatewayUrl, DAPP_RETURN_DEEP_LINK))
                     }
 
                     webViewRef.value = webView
@@ -290,8 +291,6 @@ private class PayJsBridge(
         }
     }
 }
-
-private const val APP_DEEP_LINK = "kotlin-dapp-wc://request"
 
 /**
  * Appends the two required WebView params to the API-provided gateway URL. Never construct the base


### PR DESCRIPTION
## Summary

Adds a WalletConnect Pay "checkout in a WebView" flow to the **dapp sample** (`sample/dapp/`), mirroring the React Native reference PRs [#570](https://github.com/reown-com/react-native-examples/pull/570) and [#576](https://github.com/reown-com/react-native-examples/pull/576).

The hosted checkout UI is loaded inside a native `WebView`; the app only renders it, forwards wallet deeplinks to the OS, and reacts to the result.

## What's included

- **`PayWebViewRoute`** (new) — loads the `gatewayUrl` with `returnUrl` + `preferUniversalLinks=1` appended, intercepts `?uri=wc:` wallet deeplinks (`shouldOverrideUrlLoading` → `Intent.ACTION_VIEW`), and listens for `PAY_SUCCESS` / `PAY_FAILURE` messages via the `ReactNativeWebView` JS bridge (main-thread hop). Minimal in-screen success/failure state → navigate back. Includes WebView teardown (`onRelease`) and `rememberUpdatedState` callbacks.
- **Navigation** — `Route.Pay` + `pay/{payUrlArg}` route with URL-encoded nav arg + `navigateToPay(url)` helper.
- **Entry point** — a Pay URL text field + "Open Pay checkout" button on the Chain Selection screen (https-validated).

Uses the app's already-registered `kotlin-dapp-wc://request` deep link as the wallet return destination — **no manifest, Gradle, or Activity changes required** (`WebView` is part of the framework).

## Validation notes (vs. the docs snippet)

The doc's Android/Kotlin snippet works as written for the core logic (bridge name, deeplink interception, message parsing). Fixes applied here that the bare snippet lacks:
- URL-encode the gateway URL through the Compose nav arg (raw breaks routing).
- `returnUrl` must be the registered scheme **and host** (`kotlin-dapp-wc://request`).
- WebView cleanup via `onRelease { destroy() }`.
- `rememberUpdatedState` for `onSuccess`/`onFailure`.

⚠️ `shouldOverrideUrlLoading(WebResourceRequest)` is API 24+; on the repo's minSdk 23 the deeplink interception silently no-ops. Left API-24 behavior (matches the wallet sample) — flag if the deprecated `String` overload should be added too.

## Test plan

- [x] `./gradlew :sample:dapp:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] Manual E2E on device: paste `gatewayUrl` → checkout renders → wallet deeplink opens installed wallet → return via `kotlin-dapp-wc://request` foregrounds app with WebView intact → `PAY_SUCCESS` shows Done → back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)