### PR TITLE
ci(wallet-sample): disable R8 for internal build in E2E runs

### DIFF
--- a/sample/wallet/build.gradle.kts
+++ b/sample/wallet/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
+// True only for E2E/test builds (CI sets ENABLE_TEST_MODE=true).
+val enableTestMode = System.getenv("ENABLE_TEST_MODE")?.trim()?.lowercase() == "true"
+
 android {
     namespace = "com.reown.sample.wallet"
     compileSdk = COMPILE_SDK
@@ -26,7 +29,6 @@ android {
         buildConfigField("String", "PIMLICO_API_KEY", "\"${System.getenv("PIMLICO_API_KEY") ?: ""}\"")
         buildConfigField("String", "BOM_VERSION", "\"${BOM_VERSION}\"")
         buildConfigField("String", "TEST_WALLET_PRIVATE_KEY", "\"${System.getenv("TEST_WALLET_PRIVATE_KEY") ?: ""}\"")
-        val enableTestMode = System.getenv("ENABLE_TEST_MODE")?.trim()?.lowercase() == "true"
         buildConfigField("boolean", "ENABLE_TEST_MODE", "$enableTestMode")
 
         ndk.abiFilters += listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
@@ -42,6 +44,11 @@ android {
             manifestPlaceholders["pathPrefix"] = "/wallet_internal"
             buildConfigField("String", "WALLET_APP_LINK", "\"https://appkit-lab.reown.com/wallet_internal\"")
 
+            // Disable R8 for E2E builds only: the optimized dex intermittently fails ART
+            // verification on the CI emulator and crashes on launch. Firebase builds keep R8 on.
+            if (enableTestMode) {
+                isMinifyEnabled = false
+            }
         }
 
         getByName("debug") {


### PR DESCRIPTION
## Problem

The scheduled **Pay E2E Tests with Maestro** workflow fails intermittently before any Maestro flow runs. The launch smoke check catches the wallet app crashing on startup:

```
E AndroidRuntime: Unable to instantiate application com.reown.sample.wallet.WalletKitApplication
  ... ClassNotFoundException: Didn't find class "com.reown.sample.wallet.WalletKitApplication"
E LoadedApk: ClassNotFoundException: Didn't find class "androidx.core.app.CoreComponentFactory"
```

Example failure: [run 30426861188](https://github.com/reown-com/reown-kotlin/actions/runs/30426861188/job/90495134996).

## Why this isn't a missing keep rule

- The failure is **nondeterministic** — `develop` passed 7 scheduled nights in a row, then failed, on the same build recipe. R8 shrinking is deterministic for identical bytecode, so a genuinely missing keep would fail *every* run.
- `androidx.core.app.CoreComponentFactory` is **never stripped** by R8 and doesn't need a keep — yet it's reported missing too. When both the app class and an always-kept AndroidX class vanish from the dex, the dex itself failed to load (ART dex-verify race on the CI emulator), not R8 removing code.
- PR #414 already diagnosed this as a "dex-verify flake" and tried an AGP bump; it reduced but didn't eliminate the failures.

## Fix

Disable R8 for the `internal` variant **only in E2E/test builds**, gated on the existing `ENABLE_TEST_MODE` env var (set by `ci_e2e_pay_tests.yml`, never by Firebase App Distribution builds). No CI changes needed.

| Build | `ENABLE_TEST_MODE` | R8 | Behavior |
|-------|-------------------|-----|----------|
| Pay E2E CI | `true` | off | no optimized dex → no verify flake |
| Firebase App Distribution (internal testers) | unset | on | **unchanged** |

## Verification

`assembleInternal --dry-run` task graph:
- without `ENABLE_TEST_MODE`: `minifyInternalWithR8` present (R8 on)
- with `ENABLE_TEST_MODE=true`: no R8 task (R8 off)

## Trade-off

The E2E build no longer exercises R8 before the Play `release` build does. Acceptable given the E2E build's job is to validate app behavior, not release packaging; if we want parity, the alternative is making the launch smoke check retry/settle in the `WalletConnect/actions` repo instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)