### PR TITLE
fix: prevent All Wallets bottom sheet flicker

### DIFF
--- a/product/appkit/src/main/kotlin/com/reown/appkit/ui/utils/Navigation.kt
+++ b/product/appkit/src/main/kotlin/com/reown/appkit/ui/utils/Navigation.kt
@@ -4,7 +4,7 @@ package com.reown.appkit.ui.utils
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.spring
@@ -15,7 +15,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.navigation.NavBackStackEntry
@@ -41,7 +40,17 @@ internal fun AnimatedNavGraph(
         exitTransition = { slideOutHorizontally(animationSpec = stiffnessAnimSpec) + fadeOut(animationSpec = tweenAnimSpec) },
         popEnterTransition = { slideInHorizontally(animationSpec = stiffnessAnimSpec) + fadeIn(animationSpec = tweenAnimSpec) },
         popExitTransition = { slideOutHorizontally(animationSpec = stiffnessAnimSpec) { it / 2 } + fadeOut(animationSpec = tweenAnimSpec) },
-        modifier = Modifier.animateContentSize(animationSpec = spring(stiffness = Spring.StiffnessMedium, visibilityThreshold = IntSize.VisibilityThreshold)),
+        // Keep route sizing in the same AnimatedContent transition so both destinations share clipping and measurement.
+        sizeTransform = {
+            SizeTransform(
+                sizeAnimationSpec = { _, _ ->
+                    spring(
+                        stiffness = Spring.StiffnessMedium,
+                        visibilityThreshold = IntSize.VisibilityThreshold
+                    )
+                }
+            )
+        },
         builder = builder
     )
 }


### PR DESCRIPTION
## Summary

- replace the outer `Modifier.animateContentSize` on the AppKit navigation host with AndroidX Navigation's native `SizeTransform`
- preserve the existing spring timing while coordinating destination measurement and clipping inside the same `AnimatedContent` transition
- prevent the outgoing **Connect wallet** content from showing through while the taller **All wallets** route expands

## Root cause

The Accompanist-to-AndroidX Navigation migration left route height animation on an outer modifier. AndroidX keeps both destinations composed during navigation, so the host bounds were resizing independently while the outgoing and incoming routes were being animated. The large height difference between **Connect wallet** and **All wallets** exposed the outgoing route as a flicker/bounce, especially on Xiaomi HyperOS.

## Impact

The wallet picker transition remains animated with the same spring, but route size, clipping, and measurement are now handled by one transition. This addresses [REOWN-4785](https://linear.app/reown/issue/REOWN-4785/bottom-sheet-flicker-on-all-wallets-tap-xiaomi-hyperos).

## Validation

- `./gradlew :product:appkit:compileDebugKotlin` ✅
- `./gradlew :product:appkit:assembleDebug` ✅
- `./gradlew :product:appkit:lintDebug` ✅
- `./gradlew :product:appkit:testDebugUnitTest` ⚠️ six Paparazzi tests fail during renderer initialization (`Renderer.kt` / `PaparazziSdk.kt`); none exercises navigation, and the remaining route snapshot tests are ignored in the repository

A final visual verification on the reported Xiaomi HyperOS device is recommended.