### PR TITLE
feat(tvf): collect transaction hashes for stellar_signXDR and stellar_signAndSubmitXDR

### DIFF
--- a/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/Stellar.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/Stellar.kt
@@ -1,0 +1,127 @@
+package com.reown.sign.engine.model.tvf
+
+import com.squareup.moshi.JsonClass
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.util.encoders.Base64
+
+@JsonClass(generateAdapter = true)
+data class StellarSignXDRResult(
+    val signedXDR: String,
+    val signerAddress: String?
+)
+
+@JsonClass(generateAdapter = true)
+data class StellarSignXDRParams(
+    val chain: String?
+)
+
+@JsonClass(generateAdapter = true)
+data class StellarSignAndSubmitXDRResult(
+    val tx_hash: String?,
+    val signedXDR: String?
+)
+
+object StellarSignXDR {
+    private const val PUBNET_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+    private const val TESTNET_PASSPHRASE = "Test SDF Network ; September 2015"
+
+    // XDR EnvelopeType discriminants
+    private const val ENVELOPE_TYPE_TX_V0 = 0
+    private const val ENVELOPE_TYPE_TX = 2
+    private const val ENVELOPE_TYPE_TX_FEE_BUMP = 5
+
+    // DecoratedSignature with an ed25519 signature: hint (4) + length (4, =64) + signature (64)
+    private const val DECORATED_SIGNATURE_LENGTH = 72
+    private const val ED25519_SIGNATURE_LENGTH = 64
+    private const val MAX_ENVELOPE_SIGNATURES = 20
+
+    /**
+     * Computes the Stellar transaction hash from a base64-encoded, signed TransactionEnvelope XDR
+     * as sha256(network_id || envelope_type || transaction_body). Signatures are computed over the
+     * hash, so the trailing signature array is stripped rather than hashed. For fee-bump envelopes
+     * this yields the canonical fee-bump hash.
+     *
+     * @param signedXDR base64-encoded TransactionEnvelope XDR (V0, V1 or fee-bump)
+     * @param chain CAIP-2 chain id (`stellar:pubnet` / `stellar:testnet`), defaults to pubnet
+     * @return lowercase hex transaction hash (64 chars)
+     */
+    fun computeTransactionHash(signedXDR: String, chain: String?): String {
+        val bytes = Base64.decode(signedXDR)
+        require(bytes.size >= 8) { "Stellar envelope too short" }
+
+        val discriminant = readUInt32BE(bytes, 0)
+        val envelopeType: Int
+        val bodyStart: Int
+        when (discriminant) {
+            // V0 transactions are hashed as ENVELOPE_TYPE_TX over the envelope bytes INCLUDING
+            // the leading 4 zero bytes - they double as the legacy AccountID key-type tag
+            ENVELOPE_TYPE_TX_V0 -> {
+                envelopeType = ENVELOPE_TYPE_TX
+                bodyStart = 0
+            }
+
+            ENVELOPE_TYPE_TX -> {
+                envelopeType = ENVELOPE_TYPE_TX
+                bodyStart = 4
+            }
+
+            ENVELOPE_TYPE_TX_FEE_BUMP -> {
+                envelopeType = ENVELOPE_TYPE_TX_FEE_BUMP
+                bodyStart = 4
+            }
+
+            else -> throw IllegalArgumentException("Unsupported Stellar envelope type: $discriminant")
+        }
+
+        val signatureArrayOffset = findSignatureArrayOffset(bytes)
+        val networkId = sha256(passphraseFor(chain).toByteArray(Charsets.UTF_8))
+
+        val payload = networkId +
+                byteArrayOf(0, 0, 0, envelopeType.toByte()) +
+                bytes.copyOfRange(bodyStart, signatureArrayOffset)
+
+        return sha256(payload).joinToString("") { "%02x".format(it) }
+    }
+
+    private fun passphraseFor(chain: String?): String =
+        when (chain?.substringAfterLast(':') ?: "pubnet") {
+            "pubnet" -> PUBNET_PASSPHRASE
+            "testnet" -> TESTNET_PASSPHRASE
+            else -> throw IllegalArgumentException("Unknown Stellar network: $chain")
+        }
+
+    /**
+     * Locates the start of the trailing `DecoratedSignature signatures<20>` XDR array without
+     * parsing the transaction body. Assumes ed25519 signatures (fixed 72-byte entries), which is
+     * what the WalletConnect Stellar RPC spec mandates wallets emit.
+     */
+    private fun findSignatureArrayOffset(bytes: ByteArray): Int {
+        for (signatureCount in 0..MAX_ENVELOPE_SIGNATURES) {
+            val offset = bytes.size - 4 - DECORATED_SIGNATURE_LENGTH * signatureCount
+            if (offset < 4) break
+            if (readUInt32BE(bytes, offset) != signatureCount) continue
+
+            val isValid = (0 until signatureCount).all { i ->
+                val entryOffset = offset + 4 + DECORATED_SIGNATURE_LENGTH * i
+                // each entry's signature length field must be exactly 64 (ed25519)
+                readUInt32BE(bytes, entryOffset + 4) == ED25519_SIGNATURE_LENGTH
+            }
+            if (isValid) return offset
+        }
+        throw IllegalArgumentException("Could not locate Stellar envelope signature array")
+    }
+
+    private fun readUInt32BE(bytes: ByteArray, offset: Int): Int =
+        ((bytes[offset].toInt() and 0xFF) shl 24) or
+                ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+                ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+                (bytes[offset + 3].toInt() and 0xFF)
+
+    private fun sha256(data: ByteArray): ByteArray {
+        val digest = SHA256Digest()
+        digest.update(data, 0, data.size)
+        val hash = ByteArray(digest.digestSize)
+        digest.doFinal(hash, 0)
+        return hash
+    }
+}

--- a/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/Stellar.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/Stellar.kt
@@ -6,8 +6,8 @@ import org.bouncycastle.util.encoders.Base64
 
 @JsonClass(generateAdapter = true)
 data class StellarSignXDRResult(
-    val signedXDR: String,
-    val signerAddress: String?
+    // signerAddress is intentionally omitted — only signedXDR is needed for hash computation
+    val signedXDR: String
 )
 
 @JsonClass(generateAdapter = true)
@@ -96,9 +96,12 @@ object StellarSignXDR {
      * what the WalletConnect Stellar RPC spec mandates wallets emit.
      */
     private fun findSignatureArrayOffset(bytes: ByteArray): Int {
-        for (signatureCount in 0..MAX_ENVELOPE_SIGNATURES) {
+        // Scan from the maximum count downward: a real multi-signature array must be found
+        // before the vacuously-matching zero count, which would otherwise win whenever a
+        // signature happens to end in four zero bytes.
+        for (signatureCount in MAX_ENVELOPE_SIGNATURES downTo 0) {
             val offset = bytes.size - 4 - DECORATED_SIGNATURE_LENGTH * signatureCount
-            if (offset < 4) break
+            if (offset < 4) continue
             if (readUInt32BE(bytes, offset) != signatureCount) continue
 
             val isValid = (0 until signatureCount).all { i ->

--- a/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/TNV.kt
+++ b/protocol/sign/src/main/kotlin/com/reown/sign/engine/model/tvf/TNV.kt
@@ -171,6 +171,24 @@ internal class TNV(private val moshi: Moshi) {
 
                 TON_SEND_MESSAGE -> listOf(rpcResult)
 
+                STELLAR_SIGN_XDR -> {
+                    moshi.adapter(StellarSignXDRResult::class.java)
+                        .fromJson(rpcResult)
+                        ?.let { result ->
+                            val chain = runCatching {
+                                moshi.adapter(StellarSignXDRParams::class.java).fromJson(rpcParams)?.chain
+                            }.getOrNull()
+                            listOf(StellarSignXDR.computeTransactionHash(result.signedXDR, chain))
+                        }
+                }
+
+                STELLAR_SIGN_AND_SUBMIT_XDR -> {
+                    moshi.adapter(StellarSignAndSubmitXDRResult::class.java)
+                        .fromJson(rpcResult)
+                        ?.tx_hash
+                        ?.let { listOf(it) }
+                }
+
                 else -> null
             }
         } catch (e: Exception) {
@@ -201,6 +219,8 @@ internal class TNV(private val moshi: Moshi) {
         private const val STX_TRANSFER = "stx_transferStx"
         private const val SEND_TRANSFER = "sendTransfer"
         private const val TON_SEND_MESSAGE = "ton_sendMessage"
+        private const val STELLAR_SIGN_XDR = "stellar_signXDR"
+        private const val STELLAR_SIGN_AND_SUBMIT_XDR = "stellar_signAndSubmitXDR"
 
         fun toBase58(bytes: ByteArray): String {
             val alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"

--- a/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
+++ b/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
@@ -1388,6 +1388,24 @@ class TNVTests {
     }
 
     @Test
+    fun `collectTxHashes should compute the transaction hash for a stellar V0 envelope on pubnet`() {
+        // Arrange — ENVELOPE_TYPE_TX_V0 (discriminant 0); exercises the include-leading-zeros
+        // path. Hash cross-checked against stellar-sdk's Transaction.hash().
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAAAG5btGuvFysDlQ/whfTBH8NWx1qRgzGpjtSDnJx3krOBAAAAZAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAsAAAAAAAAAZAAAAAAAAAABd5KzgQAAAEAu0xW2vwIqtuAu4/FFLWHBooGpvqn/N6iHgEX45savBk7SyoFGKIlyhG7ETZQ93tbF1OC/5ym6SdXmwIhIPQUD"
+        val rpcResult = """{"signedXDR":"$signedXDR"}"""
+        val rpcParams = """{"chain":"stellar:pubnet"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult, rpcParams)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("5b709eff53cb92c20d2c79e007f6b53ba9be04d6073119d142ffa70d7ea5c7cb"), result)
+    }
+
+    @Test
     fun `collectTxHashes should extract tx_hash for stellar_signAndSubmitXDR`() {
         // Arrange
         val rpcMethod = "stellar_signAndSubmitXDR"

--- a/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
+++ b/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
@@ -1406,6 +1406,25 @@ class TNVTests {
     }
 
     @Test
+    fun `collectTxHashes should compute the correct stellar hash when a signature ends in four zero bytes`() {
+        // Arrange — adversarial: the last 4 bytes of the (structurally valid) signature are
+        // 0x00000000, which an ascending signature-array scan mistakes for a zero-length
+        // signature array. Hash cross-checked against stellar-sdk's Transaction.hash().
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAAAgAAAABuW7RrrxcrA5UP8IX0wR/DVsdakYMxqY7Ug5ycd5KzgQAAAGQAAAAASZYC0wAAAAEAAAAAAAAAAAAAAABw29iAAAAAAAAAAAEAAAAAAAAAAQAAAABuW7RrrxcrA5UP8IX0wR/DVsdakYMxqY7Ug5ycd5KzgQAAAAAAAAAAAJiWgAAAAAAAAAABd5KzgQAAAEDGLpyx0gomLUe6OHNM90dIb/J8FPe2mR/+9m8suCVKNCF3UH6jhJthgRaiYAchg4uS+yAghMuqqTVHvyAAAAAA"
+        val rpcResult = """{"signedXDR":"$signedXDR"}"""
+        val rpcParams = """{"chain":"stellar:pubnet"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult, rpcParams)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("17e5f1f36ff6edc099fc190d24da41e48ab9dd9f0b0be6c6d68d9eba028ed8d3"), result)
+    }
+
+    @Test
     fun `collectTxHashes should extract tx_hash for stellar_signAndSubmitXDR`() {
         // Arrange
         val rpcMethod = "stellar_signAndSubmitXDR"

--- a/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
+++ b/protocol/sign/src/test/kotlin/com/reown/sign/tvf/TNVTests.kt
@@ -1316,4 +1316,102 @@ class TNVTests {
 
         assertEquals(boc, actual)
     }
+
+    // Stellar test vectors are real transactions fetched from Horizon
+    // (expected hash == the `hash` field of `GET /transactions/{hash}`).
+
+    @Test
+    fun `collectTxHashes should compute the transaction hash for stellar_signXDR on pubnet`() {
+        // Arrange
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAAAgAAAACutgsH0wwp9iT1V1zWE8jbQAm7JNeTEx4zdvWD4Jtk8wAAAGQDymekAAAAHAAAAAEAAAAAAAAAAAAAAABqguWuAAAAAAAAAAEAAAAAAAAAAQAAAACutgsH0wwp9iT1V1zWE8jbQAm7JNeTEx4zdvWD4Jtk8wAAAAAAAAAAAJiWgAAAAAAAAAAB4Jtk8wAAAECrfMK7BzVXCay0QnEItO7dJ8Ix2wGaMnFfbWHW1tE6cezMinDXiDtlVBwoK2GjAbrE0h+eGDjDqWWaRS1XDrwE"
+        val rpcResult = """{"signedXDR":"$signedXDR","signerAddress":"stellar:pubnet:GCXLMCYH2MGCT5RE6VLVZVQTZDNUACN3ETLZGEY6GN3PLA7ATNSPGGJH"}"""
+        val rpcParams = """{"xdr":"...","chain":"stellar:pubnet","account":"stellar:pubnet:GCXLMCYH2MGCT5RE6VLVZVQTZDNUACN3ETLZGEY6GN3PLA7ATNSPGGJH"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult, rpcParams)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("628ef4f404cba337f757a640260984830728c92101af0a051fb59fc8c79521c6"), result)
+    }
+
+    @Test
+    fun `collectTxHashes should default to pubnet for stellar_signXDR when chain is absent`() {
+        // Arrange
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAAAgAAAACutgsH0wwp9iT1V1zWE8jbQAm7JNeTEx4zdvWD4Jtk8wAAAGQDymekAAAAHAAAAAEAAAAAAAAAAAAAAABqguWuAAAAAAAAAAEAAAAAAAAAAQAAAACutgsH0wwp9iT1V1zWE8jbQAm7JNeTEx4zdvWD4Jtk8wAAAAAAAAAAAJiWgAAAAAAAAAAB4Jtk8wAAAECrfMK7BzVXCay0QnEItO7dJ8Ix2wGaMnFfbWHW1tE6cezMinDXiDtlVBwoK2GjAbrE0h+eGDjDqWWaRS1XDrwE"
+        val rpcResult = """{"signedXDR":"$signedXDR"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("628ef4f404cba337f757a640260984830728c92101af0a051fb59fc8c79521c6"), result)
+    }
+
+    @Test
+    fun `collectTxHashes should compute the canonical fee-bump hash for a stellar fee-bump envelope`() {
+        // Arrange
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAABQAAAAA0mMHF8QGzwsMRBhe9i8PSIqxjNjKyQMyXZODBAdhAUwAAAAAAA5+BAAAAAgAAAAA6Hd6p+AA5GTO2bJqKN/hbBfWcOh2Ow8cnTY3iIFFVPAADnrgDoCvmAAAZVgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAADod3qn4ADkZM7Zsmoo3+FsF9Zw6HY7DxydNjeIgUVU8AAAAGAAAAAAAAAAB1/5EvQrxHWArEJHy9KH03yEtRE0DIeoyrbPMHLurCgQAAAAEd29yawAAAAMAAAASAAAAAAAAAAA6Hd6p+AA5GTO2bJqKN/hbBfWcOh2Ow8cnTY3iIFFVPAAAAA0AAAAgAAAAjpSFVoEyx/Ev5d2V/desEr+GEqMyXKvrs5wXFqwAAAAFAAAAAAIrSjwAAAAAAAAAAQAAAAAAAAABAAAAB9ssFCkNSWTjgF8lJ90TKTm6X7P8ysVrML+rj9CRARYnAAAAAwAAAAYAAAAB1/5EvQrxHWArEJHy9KH03yEtRE0DIeoyrbPMHLurCgQAAAAQAAAAAQAAAAIAAAAPAAAABUJsb2NrAAAAAAAAAwACsj8AAAAAAAAABgAAAAHX/kS9CvEdYCsQkfL0ofTfIS1ETQMh6jKts8wcu6sKBAAAABAAAAABAAAAAwAAAA8AAAAEUGFpbAAAABIAAAAAAAAAADod3qn4ADkZM7Zsmoo3+FsF9Zw6HY7DxydNjeIgUVU8AAAAAwACsj8AAAAAAAAABgAAAAHX/kS9CvEdYCsQkfL0ofTfIS1ETQMh6jKts8wcu6sKBAAAABQAAAABABvFygAAAAAAAAXIAAAAAAADnrgAAAABIFFVPAAAAEBbcalx54eMMHwWJz7tzgOoxIVmMl4pexbgwTLzxnyMtAhZ2nZlsF18jIMDBaubSNSNPi4YRHkSajpyOcdZOzsCAAAAAAAAAAEB2EBTAAAAQDOlpIeUB73BImAZJCSAt0cuKZXHlKG+TJ+j+fCeFe9bDc5wHzMlDjU6YlB6geCuxRi7QwTq4RgxrOIJ9HICfg8="
+        val rpcResult = """{"signedXDR":"$signedXDR"}"""
+        val rpcParams = """{"chain":"stellar:pubnet"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult, rpcParams)
+
+        // Assert — H_fb, the hash explorers index, not the inner tx hash
+        assertNotNull(result)
+        assertEquals(listOf("5906453d5a367b4a8a1af9bbbc934904841718ec1ca1345874904e15f97bf83b"), result)
+    }
+
+    @Test
+    fun `collectTxHashes should compute the transaction hash for stellar_signXDR on testnet`() {
+        // Arrange
+        val rpcMethod = "stellar_signXDR"
+        val signedXDR =
+            "AAAAAgAAAAAJDqKNhO2/XZAvmR1Wynm2lxfIUQwB6TDzqNVOlQgQTgAAm74AJGh0ABKiOwAAAAEAAAAAAAAAAAAAAABqgthtAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABmtIg9IzJFxPz3yuidCMj3LiE2SB3XYOl8DvtohHRPVAAAAAJc2V0X3ByaWNlAAAAAAAAAwAAABIAAAAAAAAAAAkOoo2E7b9dkC+ZHVbKebaXF8hRDAHpMPOo1U6VCBBOAAAADwAAAAZFVEhVU0QAAAAAAAoAAAAAAAAAAAAAAARomVswAAAAAQAAAAAAAAAAAAAAAZrSIPSMyRcT898ronQjI9y4hNkgd12DpfA77aIR0T1QAAAACXNldF9wcmljZQAAAAAAAAMAAAASAAAAAAAAAAAJDqKNhO2/XZAvmR1Wynm2lxfIUQwB6TDzqNVOlQgQTgAAAA8AAAAGRVRIVVNEAAAAAAAKAAAAAAAAAAAAAAAEaJlbMAAAAAAAAAABAAAAAAAAAAQAAAAGAAAAAcbgeSm1T8h+V5r+/0u+qUVZIopr5hDeGKj1+u37faSgAAAAEAAAAAEAAAADAAAADwAAAAdIYXNSb2xlAAAAABIAAAAAAAAAAAkOoo2E7b9dkC+ZHVbKebaXF8hRDAHpMPOo1U6VCBBOAAAADwAAAAZPUkFDTEUAAAAAAAEAAAAGAAAAAcbgeSm1T8h+V5r+/0u+qUVZIopr5hDeGKj1+u37faSgAAAAFAAAAAEAAAAHve3Sc2JfmD0Hu+w96oFCzEX1XxFR0uE/NeSf2Vqmia8AAAAH4IWMslKp5yCKjCiGPIRV6yV0LdrLOEfRrCRSwjur0G8AAAABAAAABgAAAAGa0iD0jMkXE/PfK6J0IyPcuITZIHddg6XwO+2iEdE9UAAAABQAAAABADikCAAAAAAAAAJUAAAAAAAATa0AAAABlQgQTgAAAEDSMm2vdKNsB2TCk+Pbb6vSYgq6Zd5F0E4H5BfMi4lwWEcYFAq2Mp+e12wr1qU+Ni7+2BTqZUkb+uK7lVM8PqkN"
+        val rpcResult = """{"signedXDR":"$signedXDR"}"""
+        val rpcParams = """{"chain":"stellar:testnet"}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult, rpcParams)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("c9b2d35ab15c055acb422872a8f1680a84ad6b8ad0d56271cfb74c083edf2007"), result)
+    }
+
+    @Test
+    fun `collectTxHashes should extract tx_hash for stellar_signAndSubmitXDR`() {
+        // Arrange
+        val rpcMethod = "stellar_signAndSubmitXDR"
+        val rpcResult =
+            """{"tx_hash":"6da5298ae2b4fd1567fa3f760e66c9fb9014e3ac72bf48af1ad8120f8423b961","signedXDR":"AAAAAg==","successful":true}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult)
+
+        // Assert
+        assertNotNull(result)
+        assertEquals(listOf("6da5298ae2b4fd1567fa3f760e66c9fb9014e3ac72bf48af1ad8120f8423b961"), result)
+    }
+
+    @Test
+    fun `collectTxHashes should return null for a malformed stellar envelope`() {
+        // Arrange
+        val rpcMethod = "stellar_signXDR"
+        val rpcResult = """{"signedXDR":"q83vASNFZ4mrze8BI0VniavN7wEjRWeJq83vAQ=="}"""
+
+        // Act
+        val result = TNV.collectTxHashes(rpcMethod, rpcResult)
+
+        // Assert
+        assertNull(result)
+    }
 }


### PR DESCRIPTION
## Description

Kotlin port of [WalletConnect/walletconnect-monorepo#7318](https://github.com/WalletConnect/walletconnect-monorepo/pull/7318) — adds Stellar to TVF transaction-hash collection per the [Stellar RPC proposal](https://github.com/WalletConnectFoundation/docs/pull/154).

| Method | Strategy |
|---|---|
| `stellar_signAndSubmitXDR` | Response contains the hash — extracted from `tx_hash` |
| `stellar_signXDR` | Response contains only `signedXDR` — hash computed client-side |

### Hash computation (`tvf/Stellar.kt`)

`sha256(network_id ‖ envelope_type ‖ transaction_body)` from the base64 `TransactionEnvelope` XDR:

1. read the 4-byte envelope discriminant — V0 / V1 / fee-bump all supported
2. locate the trailing `DecoratedSignature<20>` array with a validated scan (fixed 72-byte ed25519 entries) — no full XDR schema parsing
3. network passphrase selected from the request's CAIP-2 `chain` param, defaulting to pubnet

**No new dependencies** — BouncyCastle `SHA256Digest`/`Base64` as already used by the Near and Cosmos collectors.

## Tests

6 new cases in `TNVTests` using real Horizon transactions (byte-identical vectors to the JS PR):
- pubnet V1 envelope (incl. the envelope QA-verified against Stellar Lab: `628ef4f4…`)
- pubnet fee-bump envelope with Soroban inner tx → canonical fee-bump hash
- testnet envelope (passphrase selection)
- default-to-pubnet when `chain` absent
- `tx_hash` extraction for signAndSubmit (the on-chain hash from the E2E wallet QA run: `6da5298a…`)
- malformed envelope → null

`./gradlew :protocol:sign:testDebugUnitTest --tests "com.reown.sign.tvf.TNVTests"` → BUILD SUCCESSFUL, 0 failures.

## QA context

The same algorithm was E2E-verified via react-dapp-v2 → react-wallet-v2 with the JS SDK build: `signAndSubmitXDR` hash confirmed on-chain ([stellarchain.io](https://stellarchain.io/tx/6da5298ae2b4fd1567fa3f760e66c9fb9014e3ac72bf48af1ad8120f8423b961)), `signXDR` hash confirmed against Stellar Lab's independent computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)