### PR TITLE
fix(cacao): reject expired and not-before timestamps in CacaoVerifier

### DIFF
--- a/core/android/src/main/kotlin/com/reown/android/internal/common/signing/cacao/Cacao.kt
+++ b/core/android/src/main/kotlin/com/reown/android/internal/common/signing/cacao/Cacao.kt
@@ -6,6 +6,10 @@ import com.squareup.moshi.JsonClass
 import com.reown.android.cacao.SignatureInterface
 import com.reown.android.internal.common.signing.cacao.Cacao.Payload.Companion.RECAPS_PREFIX
 import com.reown.android.internal.common.signing.signature.Signature
+import com.reown.android.internal.utils.currentTimeInSeconds
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @JsonClass(generateAdapter = true)
 data class Cacao(
@@ -75,6 +79,39 @@ data class Cacao(
 
 @JvmSynthetic
 internal fun Cacao.Signature.toSignature(): Signature = Signature.fromString(s)
+
+private val cacaoIso8601Patterns = arrayOf(
+    "yyyy-MM-dd'T'HH:mm:ssX",
+    "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+    "yyyy-MM-dd'T'HH:mm:ssXXX",
+    "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+    Cacao.Payload.ISO_8601_PATTERN,
+)
+
+internal fun parseCacaoIso8601ToEpochSeconds(value: String): Long? {
+    for (pattern in cacaoIso8601Patterns) {
+        try {
+            val format = SimpleDateFormat(pattern, Locale.US)
+            format.isLenient = false
+            val parsed = format.parse(value) ?: continue
+            return parsed.time / 1000
+        } catch (_: ParseException) {
+        }
+    }
+    return null
+}
+
+fun Cacao.Payload.isWithinValidityWindow(nowSeconds: Long = currentTimeInSeconds): Boolean {
+    exp?.let { raw ->
+        val expSeconds = parseCacaoIso8601ToEpochSeconds(raw) ?: return false
+        if (nowSeconds >= expSeconds) return false
+    }
+    nbf?.let { raw ->
+        val nbfSeconds = parseCacaoIso8601ToEpochSeconds(raw) ?: return false
+        if (nowSeconds < nbfSeconds) return false
+    }
+    return true
+}
 
 fun Cacao.Payload.toCAIP222Message(chainName: String = "Ethereum"): String {
     var message = "$domain wants you to sign in with your ${Issuer(iss).getChainName()} account:\n${Issuer(iss).address}\n\n"

--- a/core/android/src/main/kotlin/com/reown/android/internal/common/signing/cacao/CacaoVerifier.kt
+++ b/core/android/src/main/kotlin/com/reown/android/internal/common/signing/cacao/CacaoVerifier.kt
@@ -9,6 +9,10 @@ class CacaoVerifier(private val projectId: ProjectId) {
     fun verify(cacao: Cacao): Boolean = when (cacao.signature.t) {
 
         SignatureType.EIP191.header, SignatureType.EIP1271.header -> {
+            if (!cacao.payload.isWithinValidityWindow()) {
+                return false
+            }
+
             val plainMessage = cacao.payload.toCAIP222Message()
             val hexMessage = Numeric.toHexString(cacao.payload.toCAIP222Message().toByteArray())
             val address = Issuer(cacao.payload.iss).address

--- a/core/android/src/test/kotlin/com/reown/android/internal/common/signing/cacao/CacaoValidityWindowTest.kt
+++ b/core/android/src/test/kotlin/com/reown/android/internal/common/signing/cacao/CacaoValidityWindowTest.kt
@@ -1,0 +1,104 @@
+package com.reown.android.internal.common.signing.cacao
+
+import com.reown.android.cacao.signature.SignatureType
+import com.reown.android.internal.common.model.ProjectId
+import com.reown.android.utils.cacao.CacaoSignerInterface
+import com.reown.android.utils.cacao.sign
+import com.reown.util.hexToBytes
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class CacaoValidityWindowTest {
+    private val cacaoSigner = object : CacaoSignerInterface<Cacao.Signature> {}
+    private val privateKey = "305c6cde3846927892cd32762f6120539f3ec74c9e3a16b9b798b1e85351ae2a".hexToBytes()
+    private val now = 1_700_000_000L
+
+    @Test
+    fun `absent exp and nbf stay valid`() {
+        assertTrue(payload().isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `future exp stays valid`() {
+        assertTrue(payload(exp = "2024-01-01T00:00:00Z").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `past exp is expired`() {
+        assertFalse(payload(exp = "2023-01-01T00:00:00Z").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `exp equal to now is expired`() {
+        assertFalse(payload(exp = "2023-11-14T22:13:20Z").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `past nbf stays valid`() {
+        assertTrue(payload(nbf = "2023-01-01T00:00:00Z").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `future nbf is not yet valid`() {
+        assertFalse(payload(nbf = "2024-01-01T00:00:00Z").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `unparseable exp fails closed`() {
+        assertFalse(payload(exp = "not-a-timestamp").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `unparseable nbf fails closed`() {
+        assertFalse(payload(nbf = "not-a-timestamp").isWithinValidityWindow(now))
+    }
+
+    @Test
+    fun `verify rejects a signed cacao after exp`() {
+        val cacao = signedCacao(exp = "2020-01-01T00:00:00Z")
+        assertFalse(CacaoVerifier(ProjectId("")).verify(cacao))
+    }
+
+    @Test
+    fun `verify rejects a signed cacao before nbf`() {
+        val cacao = signedCacao(nbf = "2099-01-01T00:00:00Z")
+        assertFalse(CacaoVerifier(ProjectId("")).verify(cacao))
+    }
+
+    @Test
+    fun `verify rejects a signed cacao with unparseable exp`() {
+        val cacao = signedCacao(exp = "not-a-timestamp")
+        assertFalse(CacaoVerifier(ProjectId("")).verify(cacao))
+    }
+
+    @Test
+    fun `verify still accepts a currently valid signed cacao`() {
+        val cacao = signedCacao(exp = "2099-01-01T00:00:00Z", nbf = "2020-01-01T00:00:00Z")
+        assertTrue(CacaoVerifier(ProjectId("")).verify(cacao))
+    }
+
+    private fun payload(exp: String? = null, nbf: String? = null): Cacao.Payload = Cacao.Payload(
+        iss = "did:pkh:eip155:1:0x15bca56b6e2728aec2532df9d436bd1600e86688",
+        domain = "service.invalid",
+        aud = "https://service.invalid/login",
+        version = "1",
+        nonce = "32891756",
+        iat = "2021-09-30T16:25:24Z",
+        nbf = nbf,
+        exp = exp,
+        statement = "I accept the ServiceOrg Terms of Service: https://service.invalid/tos",
+        requestId = null,
+        resources = listOf(
+            "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/",
+            "https://example.com/my-web2-claim.json",
+        ),
+    )
+
+    private fun signedCacao(exp: String? = null, nbf: String? = null): Cacao {
+        val signedPayload = payload(exp = exp, nbf = nbf)
+        val message = signedPayload.toCAIP222Message()
+        val signature = cacaoSigner.sign(message, privateKey, SignatureType.EIP191)
+        return Cacao(CacaoType.EIP4361.toHeader(), signedPayload, signature)
+    }
+}


### PR DESCRIPTION
## Summary

`CacaoVerifier.verify` checked the signature only. It formatted `exp` and `nbf` into the CAIP-222 message, then returned true for any valid signature, including after `exp`, before `nbf`, or when those fields were unparseable.

Session authenticate (`OnSessionAuthenticateResponseUseCase`, `ApproveSessionAuthenticateUseCase`) and identity resolve (`IdentitiesInteractor.resolveAndStoreIdentityRemotely`) treat that boolean as the gate. Request-level `expiryTimestamp` is a different field and is not checked on the identity path.

Fail closed when `exp` is present and past or unparseable, and when `nbf` is present and future or unparseable. Absent timestamps stay optional, matching CAIP-122 / EIP-4361.

Language-split of WalletConnect/walletconnect-monorepo#7312. Distinct from reown-swift#345 (CR/LF in SIWE fields).

**Threat-model:** the attacker already holds a previously valid signed CACAO. They do not control the verifier clock or the key. After `exp` (or before `nbf`) the signature is still valid, and `verify` still returned true. That is replay after expiry, not host or agent authority.

## Test plan

- [x] `./gradlew :core:android:testDebugUnitTest --tests com.reown.android.internal.common.signing.cacao.CacaoValidityWindowTest` (12/12)
- [x] Revert-tested: removing the `isWithinValidityWindow` check in `CacaoVerifier` makes the three `verify rejects` tests fail (signature-only accepts expired, not-yet-valid, and unparseable `exp`)